### PR TITLE
non-official version of the export, with unposted entries

### DIFF
--- a/l10n_fr_fec/i18n/fr.po
+++ b/l10n_fr_fec/i18n/fr.po
@@ -110,3 +110,18 @@ msgstr "Générer"
 msgid "FEC is for French companies only !"
 msgstr "Le FEC est uniquement pour les sociétés françaises !"
 
+#. module: l10n_fr_fec
+#: selection:account.fr.fec,export_type:0
+msgid "Official FEC report (posted entries only)"
+msgstr "Rapport FEC officiel (entrées postées uniquement)"
+
+#. module: l10n_fr_fec
+#: selection:account.fr.fec,export_type:0
+msgid "Non-official FEC report (posted and unposted entries)"
+msgstr "Rapport FEC non-officiel (entrées postées et non-postées)"
+
+#. module: l10n_fr_fec
+#: field:account.fr.fec,export_type:0
+msgid "Export Type"
+msgstr "Type d'export"
+

--- a/l10n_fr_fec/i18n/l10n_fr_fec.pot
+++ b/l10n_fr_fec/i18n/l10n_fr_fec.pot
@@ -110,3 +110,18 @@ msgstr ""
 msgid "FEC is for French companies only !"
 msgstr ""
 
+#. module: l10n_fr_fec
+#: selection:account.fr.fec,export_type:0
+msgid "Official FEC report (posted entries only)"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: selection:account.fr.fec,export_type:0
+msgid "Non-official FEC report (posted and unposted entries)"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: field:account.fr.fec,export_type:0
+msgid "Export Type"
+msgstr ""
+

--- a/l10n_fr_fec/wizard/fec_view.xml
+++ b/l10n_fr_fec/wizard/fec_view.xml
@@ -16,6 +16,7 @@
             <group states="draft">
                 <field name="fiscalyear_id" />
                 <field name="type"/>
+                <field name="export_type"/>
             </group>
             <group states="done">
                 <field name="fec_data" filename="filename" />


### PR DESCRIPTION
This PR is to add a new option to the FEC wizard, "non-official", which creates a similar FEC file but with unposted entries. The goal is to allow exporting to other financial software which can use the FEC format.

The file is also renamed to mark that it is not the official report.
