### PR TITLE
Add account number in bank statement name

### DIFF
--- a/account_bank_statement_import_fr_cfonb/account_bank_statement_import_fr_cfonb.py
+++ b/account_bank_statement_import_fr_cfonb/account_bank_statement_import_fr_cfonb.py
@@ -146,7 +146,7 @@ class AccountBankStatementImport(models.TransientModel):
 
         vals_bank_statement = {
             'name': _('Account %s  %s > %s') % (
-                line_account_number, start_date_str, end_date_str),
+                account_number, start_date_str, end_date_str),
             'balance_start': start_balance,
             'balance_end_real': end_balance,
             'transactions': transactions,

--- a/account_bank_statement_import_fr_cfonb/account_bank_statement_import_fr_cfonb.py
+++ b/account_bank_statement_import_fr_cfonb/account_bank_statement_import_fr_cfonb.py
@@ -145,7 +145,8 @@ class AccountBankStatementImport(models.TransientModel):
                 vals_line['name'] += ' %s' % line[48:79].strip()
 
         vals_bank_statement = {
-            'name': _('CFONB Import %s > %s') % (start_date_str, end_date_str),
+            'name': _('Account %s  %s > %s') % (
+                line_account_number, start_date_str, end_date_str),
             'balance_start': start_balance,
             'balance_end_real': end_balance,
             'transactions': transactions,


### PR DESCRIPTION
Add account number in bank statement name. For companies with several bank accounts imported via CFONB, it will be easier to distinguish the bank statements of the different accounts.
