### PR TITLE
Better unique ID for CFONB bank statement import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - git clone https://github.com/OCA/bank-statement-import.git ${HOME}/bank-statement-import -b ${VERSION}
   - git clone https://github.com/OCA/bank-payment.git ${HOME}/bank-payment -b ${VERSION}
-  - git clone https://github.com/OCA/partner-contact.git ${HOME}/partner-contact
-  - git clone https://github.com/OCA/account-fiscal-rule.git ${HOME}/account-fiscal-rule
+  - git clone https://github.com/OCA/partner-contact.git ${HOME}/partner-contact -b ${VERSION}
+  - git clone https://github.com/OCA/account-fiscal-rule.git ${HOME}/account-fiscal-rule -b ${VERSION}
   - git clone https://github.com/OCA/community-data-files.git ${HOME}/community-data-files -b ${VERSION}
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly

--- a/account_bank_statement_import_fr_cfonb/account_bank_statement_import_fr_cfonb.py
+++ b/account_bank_statement_import_fr_cfonb/account_bank_statement_import_fr_cfonb.py
@@ -132,11 +132,13 @@ class AccountBankStatementImport(models.TransientModel):
                 bank_account_id = partner_id = False
                 amount = self._parse_cfonb_amount(line[90:104], decimals)
                 ref = line[81:88].strip()  # This is not unique
+                name = line[48:79].strip()
                 vals_line = {
                     'date': date_str,
-                    'name': line[48:79].strip(),
+                    'name': name,
                     'ref': ref,
-                    'unique_import_id': '%s-%.2f' % (ref, amount),
+                    'unique_import_id':
+                    '%s-%s-%.2f-%s' % (date_str, ref, amount, name),
                     'amount': amount,
                     'partner_id': partner_id,
                     'bank_account_id': bank_account_id,


### PR DESCRIPTION
I found out that, with some banks such as Crédit du Nord, the 'ref' field is always '000000', which makes a weaks unique_id with the current code. So I made a more complete unique_id with date and label.
