### PR TITLE
[FIX] do not include debit=credit=0 move lines (invalid for FEC)

### DIFF
--- a/l10n_fr_fec/wizard/fec.py
+++ b/l10n_fr_fec/wizard/fec.py
@@ -126,6 +126,7 @@ class account_fr_fec(orm.TransientModel):
         WHERE
             am.period_id IN %s
             AND am.company_id = %s
+            AND (aml.debit != 0 OR aml.credit != 0)
         '''
         # For official report: only use posted entries
         if cur_wiz.export_type == "official":


### PR DESCRIPTION
Forward-port of an old merge in 6.1: http://bazaar.launchpad.net/~camptocamp/openerp-french-localization/6.1-remove-null-move-lines-mdh/revision/4 , needed since move lines with debit=credit=0 are marked as invalid by the FEC validation software.
