### PR TITLE
9.0 l10n_fr_department : small usability improvements

### DIFF
--- a/l10n_fr_department/__openerp__.py
+++ b/l10n_fr_department/__openerp__.py
@@ -16,6 +16,7 @@
         'security/ir.model.access.csv',
         'data/res_country_department_data.yml',
         'view/res_country_department.xml',
+        'view/res_partner.xml',
     ],
     'post_init_hook': 'set_department_on_partner',
     'images': [

--- a/l10n_fr_department/model/res_country_department.py
+++ b/l10n_fr_department/model/res_country_department.py
@@ -22,12 +22,13 @@
 #
 ##############################################################################
 
-from openerp import models, fields, _
+from openerp import models, fields, api, _
 
 
 class ResCountryDepartment(models.Model):
     _description = "Department"
     _name = 'res.country.department'
+    _rec_name = 'display_name'
     _order = 'country_id, code'
 
     state_id = fields.Many2one(
@@ -43,8 +44,19 @@ class ResCountryDepartment(models.Model):
         string='Departement Code', size=3, required=True,
         help="""The department code."""
         """(ISO 3166-2 Codification)""")
+    display_name = fields.Char(
+        compute='compute_display_name', string='Display Name', readonly=True,
+        store=True)
 
     _sql_constraints = [
         ('code_uniq', 'unique (code)',
             _("""You cannot have two departments with the same code!""")),
     ]
+
+    @api.one
+    @api.depends('name', 'code')
+    def compute_display_name(self):
+        dname = self.name
+        if self.code:
+            dname = '%s (%s)' % (dname, self.code)
+        self.display_name = dname

--- a/l10n_fr_department/view/res_country_department.xml
+++ b/l10n_fr_department/view/res_country_department.xml
@@ -33,6 +33,8 @@
                     <group string="Group By" name="groupby">
                         <filter name="state_groupby" string="State"
                             context="{'group_by': 'state_id'}"/>
+                        <filter name="country_groupby" string="Country"
+                            context="{'group_by': 'country_id'}"/>
                     </group>
                 </search>
             </field>

--- a/l10n_fr_department/view/res_partner.xml
+++ b/l10n_fr_department/view/res_partner.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<openerp>
+<data>
+
+
+<record id="view_res_partner_filter" model="ir.ui.view">
+    <field name="name">encres.partner.search</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="base.view_res_partner_filter"/>
+    <field name="arch" type="xml">
+        <filter context="{'group_by': 'country_id'}" position="before">
+            <filter name="department_groupby" string="Department"
+                context="{'group_by': 'department_id'}"/>
+        </filter>
+    </field>
+</record>
+
+
+</data>
+</openerp>

--- a/l10n_fr_department/view/res_partner.xml
+++ b/l10n_fr_department/view/res_partner.xml
@@ -9,7 +9,7 @@
 
 
 <record id="view_res_partner_filter" model="ir.ui.view">
-    <field name="name">encres.partner.search</field>
+    <field name="name">l10n_fr_department.partner.search</field>
     <field name="model">res.partner</field>
     <field name="inherit_id" ref="base.view_res_partner_filter"/>
     <field name="arch" type="xml">


### PR DESCRIPTION
This is an up-port of the changes already merged in v8, cf https://github.com/OCA/l10n-france/pull/82

Display department with name AND code i.e. 'Rhône (69)'
Add group by in partner search view
