### PR TITLE
[9.0][CFONB]Add information in unique_import_id to ensure it is really unique

### DIFF
--- a/account_bank_statement_import_fr_cfonb/account_bank_statement_import_fr_cfonb.py
+++ b/account_bank_statement_import_fr_cfonb/account_bank_statement_import_fr_cfonb.py
@@ -149,7 +149,9 @@ class AccountBankStatementImport(models.TransientModel):
                 }
             elif rec_type == '05':
                 assert vals_line, 'vals_line should have a value !'
-                vals_line['name'] += ' %s' % line[48:79].strip()
+                name_ext = line[48:79].strip()
+                vals_line['name'] += ' %s' % name_ext
+                vals_line['unique_import_id'] += '-%s' % name_ext
 
         vals_bank_statement = {
             'name': _('Account %s %s > %s') % (


### PR DESCRIPTION
I have a case where, within the same CFONB file I have 2 identical unique_import_id.
To avoid this case, wen can add additional information into the field and avoid the problem.