### PR TITLE
[8.0] LCR: FIX don't crash when bank account is missing on a payment line

### DIFF
--- a/account_banking_fr_lcr/wizard/export_lcr.py
+++ b/account_banking_fr_lcr/wizard/export_lcr.py
@@ -186,6 +186,9 @@ class BankingExportLcrWizard(models.TransientModel):
         numero_enregistrement = str(transactions_count + 1).zfill(8)
         reference_tire = self._prepare_field(
             u'Référence tiré', line.communication, 10)
+        if not line.bank_id:
+            raise Warning(_(
+                "Missing bank account on bank payment line %s.") % line.name)
         rib = self._get_rib_from_iban(line.bank_id)
 
         nom_tire = self._prepare_field(


### PR DESCRIPTION
It will display an explicit error msg instead of a crash popup.