### PR TITLE
Replace \r \n \t in export to avoid file interpretation errors + add encoding option

### DIFF
--- a/l10n_fr_fec/README.rst
+++ b/l10n_fr_fec/README.rst
@@ -21,7 +21,7 @@ FEC au format texte et non au format XML, car le format texte sera facilement
 lisible et vérifiable par le comptable en utilisant un tableur.
 
 La structure du fichier FEC généré par ce module a été vérifiée avec le logiciel
-*Test Compta Demat* version 1_00_05 disponible sur
+*Test Compta Demat* version 1_00_06 disponible sur
 `le site de la direction générale des finances publiques <http://www.economie.gouv.fr/dgfip/outil-test-des-fichiers-des-ecritures-comptables-fec>`
 en utilisant une base de donnée Odoo réelle.
 

--- a/l10n_fr_fec/README.rst
+++ b/l10n_fr_fec/README.rst
@@ -1,3 +1,8 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================================================
 Fichier d'Échange Informatisé (FEC) pour la France
 ==================================================
 
@@ -31,6 +36,18 @@ Utilisation
 Pour générer le *FEC*, allez dans le menu *Accounting > Reporting > Legal
 Reports > Journals > FEC* qui va démarrer l'assistant de génération du FEC.
 
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/121/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/l10n-france/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
 Credits
 =======
 
@@ -42,12 +59,14 @@ Contributors
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
-OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/l10n_fr_fec/__init__.py
+++ b/l10n_fr_fec/__init__.py
@@ -1,23 +1,3 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    l10n FR FEC module for Odoo
-#    Copyright (C) 2013-2015 Akretion (http://www.akretion.com)
-#    @author Alexis de Lattre <alexis.delattre@akretion.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
 
 from . import wizard

--- a/l10n_fr_fec/__openerp__.py
+++ b/l10n_fr_fec/__openerp__.py
@@ -1,29 +1,11 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    l10n FR FEC module for Odoo
-#    Copyright (C) 2013-2015 Akretion (http://www.akretion.com)
-#    @author Alexis de Lattre <alexis.delattre@akretion.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-
+# -*- coding: utf-8 -*-
+# © 2013-2017 Akretion (http://www.akretion.com)
+# @author Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     'name': 'France - FEC',
-    'version': '8.0.0.1.0',
+    'version': '8.0.0.2.0',
     'category': 'French Localization',
     'license': 'AGPL-3',
     'summary': "Fichier d'Échange Informatisé (FEC) for France",
@@ -31,7 +13,7 @@
     'website': 'http://www.akretion.com',
     'depends': ['account_accountant'],
     'external_dependencies': {
-        'python': ['unicodecsv'],
+        'python': ['unicodecsv', 'unidecode'],
         },
     'data': [
         'wizard/fec_view.xml',

--- a/l10n_fr_fec/wizard/__init__.py
+++ b/l10n_fr_fec/wizard/__init__.py
@@ -1,23 +1,3 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    l10n FR FEC module for Odoo
-#    Copyright (C) 2013-2015 Akretion (http://www.akretion.com)
-#    @author Alexis de Lattre <alexis.delattre@akretion.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
 
 from . import fec

--- a/l10n_fr_fec/wizard/fec.py
+++ b/l10n_fr_fec/wizard/fec.py
@@ -84,38 +84,38 @@ class AccountFrFec(models.TransientModel):
         company = self.fiscalyear_id.company_id
         encoding = self.encoding
 
-        sql_query = '''
+        sql_query = r'''
         SELECT
             regexp_replace(
-            aj.code, E'[\\n\\r\\t\|]+', '/', 'g') AS JournalCode,
+            aj.code, E'[\n\r\t\|]+', '/', 'g') AS JournalCode,
             regexp_replace(
-            aj.name, E'[\\n\\r\\t\|]+', '/', 'g') AS JournalLib,
+            aj.name, E'[\n\r\t\|]+', '/', 'g') AS JournalLib,
             regexp_replace(
-            am.name, E'[\\n\\r\\t\|]+', '/', 'g') AS EcritureNum,
+            am.name, E'[\n\r\t\|]+', '/', 'g') AS EcritureNum,
             am.date AS EcritureDate,
             aa.code AS CompteNum,
             regexp_replace(
-            aa.name, E'[\\n\\r\\t\|]+', '/', 'g') AS CompteLib,
+            aa.name, E'[\n\r\t\|]+', '/', 'g') AS CompteLib,
             CASE WHEN rp.ref IS null OR rp.ref = ''
             THEN 'ID ' || rp.id
             ELSE rp.ref
             END
             AS CompAuxNum,
             regexp_replace(
-            rp.name, E'[\\n\\r\\t\|]+', '/', 'g') AS CompAuxLib,
+            rp.name, E'[\n\r\t\|]+', '/', 'g') AS CompAuxLib,
             CASE WHEN am.ref IS null OR am.ref = ''
             THEN '-'
             ELSE regexp_replace(
-            am.ref, E'[\\n\\r\\t\|]+', '/', 'g')
+            am.ref, E'[\n\r\t\|]+', '/', 'g')
             END
             AS PieceRef,
             am.date AS PieceDate,
             regexp_replace(
-            aml.name, E'[\\n\\r\\t\|]+', '/', 'g') AS EcritureLib,
+            aml.name, E'[\n\r\t\|]+', '/', 'g') AS EcritureLib,
             aml.debit AS Debit,
             aml.credit AS Credit,
             regexp_replace(
-            amr.name, E'[\\n\\r\\t\|]+', '/', 'g') AS EcritureLet,
+            amr.name, E'[\n\r\t\|]+', '/', 'g') AS EcritureLet,
             amr.create_date::timestamp::date AS DateLet,
             am.date AS ValidDate,
             aml.amount_currency AS Montantdevise,

--- a/l10n_fr_fec/wizard/fec.py
+++ b/l10n_fr_fec/wizard/fec.py
@@ -1,29 +1,23 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    l10n FR FEC module for Odoo
-#    Copyright (C) 2013-2015 Akretion (http://www.akretion.com)
-#    @author Alexis de Lattre <alexis.delattre@akretion.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2013-2017 Akretion (http://www.akretion.com)
+# @author Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import models, fields, api, _
-from openerp.exceptions import Warning
+from openerp.exceptions import Warning as UserError
 import base64
 import StringIO
+import logging
+logger = logging.getLogger(__name__)
+
+try:
+    from unidecode import unidecode
+except ImportError:
+    logger.debug('Cannot import unidecode')
+try:
+    import unicodecsv
+except ImportError:
+    logger.debug('Cannot import unicodecsv')
 
 
 class AccountFrFec(models.TransientModel):
@@ -34,23 +28,27 @@ class AccountFrFec(models.TransientModel):
         'account.fiscalyear', string='Fiscal Year', required=True)
     type = fields.Selection([
         ('is_ir_bic', 'I.S. or BIC @ I.R.'),
-    ], string='Company Type', default='is_ir_bic')
+        ], string='Company Type', default='is_ir_bic')
+    encoding = fields.Selection([
+        ('iso8859_15', 'ISO-8859-15'),
+        ('utf-8', 'UTF-8'),
+        ('ascii', 'ASCII'),
+        ], string='Encoding', default='iso8859_15', required=True)
     fec_data = fields.Binary('FEC File', readonly=True)
     filename = fields.Char(string='Filename', size=256, readonly=True)
     state = fields.Selection([
         ('draft', 'Draft'),
         ('done', 'Done'),
-    ], string='State', default='draft')
+        ], string='State', default='draft')
     export_type = fields.Selection([
         ('official', 'Official FEC report (posted entries only)'),
         (
             'nonofficial',
             'Non-official FEC report (posted and unposted entries)'),
-    ], string='Export Type', required=True, default='official')
+        ], string='Export Type', required=True, default='official')
 
     @api.multi
     def generate_fec(self):
-        import unicodecsv
         self.ensure_one()
         assert self.fiscalyear_id.period_ids,\
             'The Fiscal Year must have periods'
@@ -81,9 +79,10 @@ class AccountFrFec(models.TransientModel):
             'ValidDate',      # 15
             'Montantdevise',  # 16
             'Idevise',        # 17
-        ]
+            ]
 
         company = self.fiscalyear_id.company_id
+        encoding = self.encoding
 
         sql_query = '''
         SELECT
@@ -95,7 +94,8 @@ class AccountFrFec(models.TransientModel):
             am.name, E'[\\n\\r\\t\|]+', '/', 'g') AS EcritureNum,
             am.date AS EcritureDate,
             aa.code AS CompteNum,
-            replace(aa.name, '|', '/') AS CompteLib,
+            regexp_replace(
+            aa.name, E'[\\n\\r\\t\|]+', '/', 'g') AS CompteLib,
             CASE WHEN rp.ref IS null OR rp.ref = ''
             THEN 'ID ' || rp.id
             ELSE rp.ref
@@ -150,7 +150,8 @@ class AccountFrFec(models.TransientModel):
             sql_query, (tuple(self.fiscalyear_id.period_ids.ids), company.id))
 
         fecfile = StringIO.StringIO()
-        w = unicodecsv.writer(fecfile, encoding='utf-8', delimiter='|')
+        w = unicodecsv.writer(
+            fecfile, encoding=encoding, errors='replace', delimiter='|')
         w.writerow(header)
 
         while 1:
@@ -175,18 +176,24 @@ class AccountFrFec(models.TransientModel):
                 listrow[12] = ('%.2f' % listrow[12]).replace('.', ',')
                 if listrow[16]:
                     listrow[16] = ('%.2f' % listrow[16]).replace('.', ',')
+                if encoding == 'ascii':
+                    for char_col in [1, 5, 7, 8, 10]:
+                        listrow[char_col] = unidecode(listrow[char_col])
+                # I don't do a special treatment for 'latin1' ; I just
+                # take advantage of unicodecsv.writer(errors='replace')
+                # -> unicode caracters not available in latin1 will be
+                # replaced by '?'
                 w.writerow(listrow)
 
         if company.vat:
             vat = company.vat.replace(' ', '')
             if vat[0:2] != 'FR':
-                raise Warning(
-                    _("FEC is for French companies only !"))
+                raise UserError(_("FEC is for French companies only !"))
             siren = vat[4:13]
         elif company.siret:
             siren = company.siret[0:9]
         else:
-            raise Warning(_(
+            raise UserError(_(
                 "Missing VAT number and SIRET for company %s") % company.name)
         fy_end_date = self.fiscalyear_id.date_stop.replace('-', '')
         suffix = ''
@@ -198,7 +205,7 @@ class AccountFrFec(models.TransientModel):
             'fec_data': base64.encodestring(fecvalue),
             'filename': '%sFEC%s%s.csv' % (siren, fy_end_date, suffix),
             # Filename = <siren>FECYYYYMMDD where YYYMMDD is the closing date
-        })
+            })
         fecfile.close()
 
         action = {
@@ -208,5 +215,5 @@ class AccountFrFec(models.TransientModel):
             'res_model': self._name,
             'res_id': self.id,
             'target': 'new',
-        }
+            }
         return action

--- a/l10n_fr_fec/wizard/fec_view.xml
+++ b/l10n_fr_fec/wizard/fec_view.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Copyright (C) 2013-2015 Akretion (http://www.akretion.com)
+  © 2013-2017 Akretion (http://www.akretion.com)
   @author: Alexis de Lattre <alexis.delattre@akretion.com>
-  The licence is in the file __openerp__.py
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 <openerp>
 <data>
@@ -13,15 +13,15 @@
     <field name="arch" type="xml">
         <form string="FEC File Generation">
             <field name="state" invisible="True"/>
-            <group states="draft">
-                <field name="fiscalyear_id" />
-                <field name="type"/>
-                <field name="export_type"/>
+            <group name="params">
+                <field name="fiscalyear_id" attrs="{'readonly': [('state', '=', 'done')]}"/>
+                <field name="type" attrs="{'readonly': [('state', '=', 'done')]}"/>
+                <field name="export_type" attrs="{'readonly': [('state', '=', 'done')]}"/>
+                <field name="encoding" attrs="{'readonly': [('state', '=', 'done')]}"/>
             </group>
-            <group states="done">
+            <group states="done" name="fec_file">
                 <field name="fec_data" filename="filename" />
                 <field name="filename" invisible="True"/>
-                <label string="The encoding of this text file is UTF-8." colspan="2"/>
             </group>
             <footer>
                 <button string="Generate" name="generate_fec" type="object"


### PR DESCRIPTION
For the real case of use several account move lines are imported from external source. 
This import can contain some special characters which generate a fec file with interpretation errors.