### PR TITLE
[10.0][FIX] Invoice transmission via Chorus API when using py3o

### DIFF
--- a/l10n_fr_chorus_account/views/account_invoice.xml
+++ b/l10n_fr_chorus_account/views/account_invoice.xml
@@ -13,7 +13,7 @@
     <field name="inherit_id" ref="account_invoice_transmit_method.invoice_form"/>
     <field name="arch" type="xml">
         <button name="action_invoice_sent" position="after">
-            <button name="%(account_invoice_chorus_send_action)d" type="action" attrs="{'invisible': ['|', '|', ('sent', '=', True), ('state', 'not in', ('open', 'paid')), ('transmit_method_code', '!=', 'fr-chorus')]}" string="Send to Chorus" class="btn-primary" groups="l10n_fr_chorus_account.group_chorus_api"/>
+            <button name="%(account_invoice_chorus_send_action)d" type="action" attrs="{'invisible': ['|', '|', ('chorus_flow_id', '!=', False), ('state', 'not in', ('open', 'paid')), ('transmit_method_code', '!=', 'fr-chorus')]}" string="Send to Chorus" class="btn-primary" groups="l10n_fr_chorus_account.group_chorus_api"/>
         </button>
         <notebook position="inside">
             <page name="fr-chorus" string="Chorus" attrs="{'invisible': [('transmit_method_code', '!=', 'fr-chorus')]}" groups="l10n_fr_chorus_account.group_chorus_api">

--- a/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py
+++ b/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py
@@ -39,10 +39,12 @@ class AccountInvoiceChorusSend(models.TransientModel):
                     "'Chorus'.")
                     % (invoice.display_name,
                        invoice.transmit_method_id.name or _('None')))
-            if invoice.sent:
+            if invoice.chorus_flow_id:
                 raise UserError(_(
-                    "The invoice '%s' has already been sent.")
-                    % invoice.display_name)
+                    "The invoice '%s' has already been sent: it is linked to "
+                    "Chorus Flow %s.") % (
+                        invoice.display_name,
+                        invoice.chorus_flow_id.display_name))
             if company:
                 if company != invoice.company_id:
                     raise UserError(_(

--- a/l10n_fr_chorus_factur-x/models/account_invoice.py
+++ b/l10n_fr_chorus_factur-x/models/account_invoice.py
@@ -31,8 +31,9 @@ class AccountInvoice(models.Model):
         elif chorus_invoice_format == 'pdf_factur-x':
             # deposerFlux works in Factur-X for single invoice,
             # but not in multi-invoice with tarball
-            chorus_file_content = self.env['report'].get_pdf(
-                self.ids, 'account.report_invoice')
+            chorus_file_content, filetype = self.env['ir.actions.report.xml'].\
+                render_report(self.ids, 'account.report_invoice', {})
+            assert filetype == 'pdf', 'wrong filetype'
         else:
             chorus_file_content = super(AccountInvoice, self).\
                 chorus_get_invoice(chorus_invoice_format)


### PR DESCRIPTION
Now use the py3o report instead of qweb report when the invoice is py3o (Thanks to Laurent Mignon from Acsone for this very kind help)

Fix display of the "Send to Chorus Pro" button