### PR TITLE
[8.0] account_balance_ebp_csv_export: add initial balance in SldCptNDebit and SldCptNCredit

### DIFF
--- a/account_balance_ebp_csv_export/wizard/trial_balance_wizard.py
+++ b/account_balance_ebp_csv_export/wizard/trial_balance_wizard.py
@@ -52,6 +52,13 @@ class ReportEBP(interface.report_int):
         for current_account in objects:
             if ctx_val['to_display_accounts'].get(current_account.id) \
                     and current_account.type != 'view':
+                initial_bal = ctx_val['init_balance_accounts'][current_account.id]
+                debit = ctx_val['debit_accounts'][current_account.id]
+                credit = ctx_val['credit_accounts'][current_account.id]
+                if initial_bal >= 0:
+                    debit += initial_bal
+                else:
+                    credit -= initial_bal
                 bal = ctx_val['balance_accounts'][current_account.id]
                 if bal >= 0:
                     bal_debit = bal
@@ -63,8 +70,8 @@ class ReportEBP(interface.report_int):
                 w.writerow([
                     current_account.code,
                     current_account.name,
-                    f2s(ctx_val['debit_accounts'][current_account.id]),
-                    f2s(ctx_val['credit_accounts'][current_account.id]),
+                    f2s(debit),
+                    f2s(credit),
                     f2s(bal_debit),
                     f2s(bal_credit),
                     ])


### PR DESCRIPTION
Take into account initial balance in the columns Balance.SldCptNDebit and Balance.SldCptNCredit.
We found this requirement when using EBP liasse fiscale, which is expecting this. We didn't experience this problem when using Teledec or Sage Liasse fiscale (certainly because they ignored these columns and only used the 2 last columns Balance.SldCptNSoldeD and Balance.SldCptNSoldeC.