### PR TITLE
[IMP][l10n_fr_intrastat_product] Remove l10n_fr_siret dependency

### DIFF
--- a/l10n_fr_intrastat_product/__manifest__.py
+++ b/l10n_fr_intrastat_product/__manifest__.py
@@ -4,15 +4,15 @@
 
 {
     'name': 'DEB',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'category': 'Localisation/Report Intrastat',
     'license': 'AGPL-3',
     'summary': "DEB (Déclaration d'Échange de Biens) for France",
     'author': 'Akretion,Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/l10n-france',
     'depends': [
+        'l10n_fr',
         'intrastat_product',
-        'l10n_fr_siret',
         'l10n_fr_department',
         ],
     'data': [

--- a/l10n_fr_intrastat_product/demo/intrastat_demo.xml
+++ b/l10n_fr_intrastat_product/demo/intrastat_demo.xml
@@ -17,8 +17,7 @@
 </record>
 
 <record id="base.main_partner" model="res.partner">
-    <field name="siren">441019213</field>
-    <field name="nic">00013</field>
+    <field name="siret">44101921300013</field>
 </record>
 
 <record id="intrastat_product.intrastat_unit_pce" model="intrastat.unit">


### PR DESCRIPTION
It's actually not needed. We already have `company_id.siret` in `l10n_fr`.
l10n_fr_siret adds siret computation based on siren and nic. It's nice, but not needed in this module.

