### PR TITLE
12.0 - FIX prevent install l10n_fr_account_invoice_facturx in travis settings because it break tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,9 @@ env:
   - secure: axBDnKRsoWFK+yYseiC2VZ76aiKjRnT25p4R7wtMs0UXhydbJvac1lWEUWVm8XwiMKNK+sor3csVlm6mfuAqEAtBtC6mprS4oFgFdUSPoA0pPus99GLkOXJw6AD00R1p3O5S6ukQ1JNhMJZvIRhKFm+icd8+VJkn8GGclnuqrp4=
   matrix:
   - LINT_CHECK="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo" MAKEPOT="1"
-  - TESTS="1" ODOO_REPO="OCA/OCB"
+  # Exclusion because of conflict with odoo 'account_facturx' module
+  - TESTS="1" ODOO_REPO="odoo/odoo" MAKEPOT="1" EXCLUDE="l10n_fr_account_invoice_facturx"
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="l10n_fr_account_invoice_facturx"
 
 
 install:


### PR DESCRIPTION
It's patch while we find a better way to test this module without break repository.
Maybe remove `auto_install` of `account_facturx` module in OCB