### PR TITLE
[ADD] l10n-fr-post-on-validation

### DIFF
--- a/l10n_fr_post_on_validation/README.rst
+++ b/l10n_fr_post_on_validation/README.rst
@@ -1,0 +1,3 @@
+This module disables the post done during process_reconciliation.
+
+The purpose is to not post the entries yet, as there is no possibility to edit if l10n_fr_certification is installed. With this addon only once a bank statement is validated will the moves be posted.

--- a/l10n_fr_post_on_validation/__init__.py
+++ b/l10n_fr_post_on_validation/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_fr_post_on_validation/__manifest__.py
+++ b/l10n_fr_post_on_validation/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'French localization Acount reconcile post on validation',
+    'summary': 'Leaves moves in unposted on reconcile only posts when validated.',
+    'version': '12.0.1.0.0',
+    'author': 'Camptocamp',
+    'maintainer': 'Camptocamp',
+    'category': 'Sale',
+    'installable': True,
+    'license': 'AGPL-3',
+    'application': False,
+    'depends': [
+        'account',
+        'l10n_fr_certification'
+    ],
+    'website': 'http://www.camptocamp.com',
+    'data': [
+        'views/account_views.xml'
+    ],
+}

--- a/l10n_fr_post_on_validation/models/__init__.py
+++ b/l10n_fr_post_on_validation/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_bank_statement_line
+from . import account_move

--- a/l10n_fr_post_on_validation/models/account_bank_statement_line.py
+++ b/l10n_fr_post_on_validation/models/account_bank_statement_line.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+
+class AccountBankStatementLine(models.Model):
+    _inherit = "account.bank.statement.line"
+
+    def process_reconciliation(
+        self,
+        counterpart_aml_dicts=None,
+        payment_aml_rec=None,
+        new_aml_dicts=None,
+    ):
+        if payment_aml_rec:
+            payment_aml_rec = payment_aml_rec.with_context(no_post=True)
+
+        return super(
+            AccountBankStatementLine, self.with_context(no_post=True)
+        ).process_reconciliation(
+            counterpart_aml_dicts, payment_aml_rec, new_aml_dicts
+        )

--- a/l10n_fr_post_on_validation/models/account_move.py
+++ b/l10n_fr_post_on_validation/models/account_move.py
@@ -1,0 +1,21 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.multi
+    def post(self, invoice=False):
+        # This is stupid, but better to override a 200 line function without
+        # calling super to remove one line
+        if 'no_post' not in self.env.context:
+            return super().post(invoice)
+        return
+
+    @api.multi
+    def button_cancel(self):
+        return super(
+            AccountMove, self.filtered(lambda x: x.state != 'draft')
+        ).button_cancel()

--- a/l10n_fr_post_on_validation/tests/test_post_on_validation.py
+++ b/l10n_fr_post_on_validation/tests/test_post_on_validation.py
@@ -1,0 +1,161 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from datetime import date
+
+from odoo.addons.account.tests.account_test_classes import AccountingTestCase
+
+
+# Most setup is copied from odoo accounting bank_statement_reconcilation tests
+class TestPostOnValidation(AccountingTestCase):
+    def setUp(self):
+        super(TestPostOnValidation, self).setUp()
+        self.i_model = self.env['account.invoice']
+        self.il_model = self.env['account.invoice.line']
+        self.bs_model = self.env['account.bank.statement']
+        self.bsl_model = self.env['account.bank.statement.line']
+        self.partner = self.env['res.partner'].create({'name': 'test'})
+
+    def test_full_reconcile(self):
+        self._reconcile_invoice_with_statement(False)
+
+    def test_post_at_bank_rec_full_reconcile(self):
+        self._reconcile_invoice_with_statement(True)
+
+    def _reconcile_invoice_with_statement(self, post_at_bank_rec):
+        # The post_at_bank_reconciliation flag changes when the move is posted.
+        # we want to make sure our addon is working with both settings,
+        # so this function is used twice
+        self.bs_model.with_context(
+            journal_type='bank'
+        )._default_journal().post_at_bank_reconciliation = post_at_bank_rec
+        rcv_mv_line = self.create_invoice(100)
+        st_line = self.create_statement_line(100)
+        # reconcile
+        st_line.process_reconciliation(
+            counterpart_aml_dicts=[
+                {
+                    'move_line': rcv_mv_line,
+                    'credit': 100,
+                    'debit': 0,
+                    'name': rcv_mv_line.name,
+                }
+            ]
+        )
+
+        # check everything went as expected
+        self.assertTrue(st_line.journal_entry_ids)
+        move = st_line.journal_entry_ids.mapped('move_id')
+        self.assertEqual(move.state, 'draft')
+        st_line.statement_id.balance_end_real = 100.0
+        st_line.statement_id.button_confirm_bank()
+        self.assertEqual(move.state, 'posted')
+
+    def create_invoice(self, amount):
+        vals = {
+            'partner_id': self.partner.id,
+            'type': 'out_invoice',
+            'name': '-',
+            'currency_id': self.env.user.company_id.currency_id.id,
+        }
+        # new creates a temporary record to apply the on_change afterwards
+        invoice = self.i_model.new(vals)
+        invoice._onchange_partner_id()
+        vals.update({'account_id': invoice.account_id.id})
+        self.invoice = self.i_model.create(vals)
+
+        self.il_model.create(
+            {
+                'quantity': 1,
+                'price_unit': amount,
+                'invoice_id': self.invoice.id,
+                'name': '.',
+                'account_id': self.env['account.account']
+                .search(
+                    [
+                        (
+                            'user_type_id',
+                            '=',
+                            self.env.ref(
+                                'account.data_account_type_revenue'
+                            ).id,
+                        )
+                    ],
+                    limit=1,
+                )
+                .id,
+            }
+        )
+        self.invoice.action_invoice_open()
+
+        mv_line = None
+        for line in self.invoice.move_id.line_ids:
+            if line.account_id.id == vals['account_id']:
+                mv_line = line
+        self.assertIsNotNone(mv_line)
+
+        return mv_line
+
+    def create_statement_line(self, st_line_amount):
+        journal = self.bs_model.with_context(
+            journal_type='bank'
+        )._default_journal()
+        bank_stmt = self.bs_model.create({'journal_id': journal.id})
+
+        bank_stmt_line = self.bsl_model.create(
+            {
+                'name': '_',
+                'statement_id': bank_stmt.id,
+                'partner_id': self.partner.id,
+                'amount': st_line_amount,
+            }
+        )
+
+        return bank_stmt_line
+
+    def test_reconcile_with_account_payment(self):
+        journal = self.bs_model.with_context(
+            journal_type='bank'
+        )._default_journal()
+        journal.post_at_bank_reconciliation = True
+        rcv_mv_line = self.create_invoice(100)
+        payment = self.env['account.payment'].create(
+            {
+                'payment_type': 'inbound',
+                'payment_method_id': self.env.ref(
+                    'account.account_payment_method_manual_in'
+                ).id,
+                'partner_type': 'customer',
+                'partner_id': self.partner.id,
+                'amount': 100,
+                'currency_id': self.currency_usd_id,
+                'payment_date': date.today(),
+                'journal_id': journal.id,
+            }
+        )
+        payment.post()
+        payment_move_line = False
+        for line in payment.move_line_ids:
+            if line.account_id.user_type_id.name == 'Receivable':
+                payment_move_line = line
+        self.invoice.register_payment(payment_move_line)
+
+        st_line = self.create_statement_line(100)
+        # reconcile
+        st_line.process_reconciliation(
+            counterpart_aml_dicts=[
+                {
+                    'move_line': rcv_mv_line,
+                    'credit': 100,
+                    'debit': 0,
+                    'name': rcv_mv_line.name,
+                }
+            ]
+        )
+
+        # check everything went as expected
+        self.assertTrue(st_line.journal_entry_ids)
+        move = st_line.journal_entry_ids.mapped('move_id')
+        self.assertEqual(move.state, 'draft')
+        st_line.statement_id.balance_end_real = 100.0
+        st_line.statement_id.button_confirm_bank()
+        self.assertEqual(move.state, 'posted')

--- a/l10n_fr_post_on_validation/views/account_views.xml
+++ b/l10n_fr_post_on_validation/views/account_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_bank_statement_form" model="ir.ui.view">
+        <field name="name">bank.statement.cancel.form.inherit</field>
+        <field name="model">account.bank.statement</field>
+        <field name="inherit_id" ref="account.view_bank_statement_form"/>
+        <field name="arch" type="xml">
+            <field name="line_ids" position="attributes">
+                <attribute name="options">{'reload_on_button': true}</attribute>
+            </field>
+            <xpath expr="//field[@name='bank_account_id']" position="after">
+                <field name="state" invisible="1"/>
+                <button name="button_cancel_reconciliation" attrs="{'invisible': ['|',('journal_entry_ids', '=', []), ('state', '=', 'confirm')]}" string="Revert reconciliation" type="object" icon="fa-undo"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION


This module disables the post done during process_reconciliation.

The purpose is to not post the entries yet, as there is no possibility to edit if l10n_fr_certification is installed. With this addon only once a bank statement is validated will the moves be posted.
