### PR TITLE
[10.0] l10n_fr_fec_oca: Backport from v12 with fixes and improvements

### DIFF
--- a/l10n_fr_fec_oca/wizard/account_fr_fec_oca_view.xml
+++ b/l10n_fr_fec_oca/wizard/account_fr_fec_oca_view.xml
@@ -13,9 +13,7 @@
                         <field name="date_range_id"/>
                         <field name="date_from"/>
                         <field name="date_to"/>
-                        <field name="official"/>
-                        <field name="target_move" attrs="{'readonly': [('official', '=', True)]}" widget="radio"/>
-                        <field name="include_initial_balance" attrs="{'readonly': [('official', '=', True)]}"/>
+                        <field name="export_type"/>
                         <field name="encoding"/>
                         <field name="delimiter"/>
                         <field name="partner_option" widget="radio"/>


### PR DESCRIPTION
Backport of PR #261 
Fix missing data due to a line of code that was accessing the ORM
between cr.execute() and cr.fetchall(), so cr.fetchall() was always
empty. I'm really sorry for that...

Improve the 120/129 line: auto-switch to 129000 with appropriate label
when it's a loss
Add complete support for the option about partners, including in the
initial balances.