### PR TITLE
[14.0] l10n_fr_siret: add warning for duplicates

### DIFF
--- a/l10n_fr_siret/views/partner.xml
+++ b/l10n_fr_siret/views/partner.xml
@@ -44,6 +44,20 @@
                 />
                 <field name="siret" attrs="{'invisible': [('type','=', 'contact')]}" />
             </xpath>
+            <div
+                attrs="{'invisible': [('same_vat_partner_id', '=', False)]}"
+                position="after"
+            >
+                <div
+                    class="alert alert-warning"
+                    role="alert"
+                    attrs="{'invisible': [('same_siren_partner_id', '=', False)]}"
+                >
+                  Duplicate warning: there is another partner with the same SIREN: <field
+                        name="same_siren_partner_id"
+                    />.
+                </div>
+            </div>
             <!-- TODO When base_view_inheritance_extension will be ported to v14, add default_nic to context of child_ids -->
         </field>
     </record>


### PR DESCRIPTION

![siren_dup](https://user-images.githubusercontent.com/1157917/108428159-7025db00-723e-11eb-81b7-4183a763b022.png)

This warning is similar to the warning on VAT duplicate in the 'base' module