### PR TITLE
[FIX] l10n_fr_chorus_account: out-of-date, broken translations

### DIFF
--- a/l10n_fr_chorus_account/i18n/fr.po
+++ b/l10n_fr_chorus_account/i18n/fr.po
@@ -1,242 +1,225 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_fr_chorus_account
+#	* l10n_fr_chorus_account
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:34+0000\n"
-"PO-Revision-Date: 2018-07-19 17:15+0000\n"
-"Last-Translator: Christophe CHAUVET <christophe.chauvet@gmail.com>\n"
-"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
-"Language: fr\n"
+"POT-Creation-Date: 2021-03-16 15:25+0000\n"
+"PO-Revision-Date: 2021-03-16 15:25+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 3.0.1\n"
+"Plural-Forms: \n"
 
 #. module: l10n_fr_chorus_account
 #: model:mail.template,body_html:l10n_fr_chorus_account.chorus_api_expiry_reminder_mail_template
-msgid ""
+msgid "\n"
+"<p>The Odoo server of company <em>${object.name}</em> is configured to access the Chorus Pro API. Accessing the Chorus Pro API requires a technical user login and password. The password of the technical user has an expiry date. The password of the technical user expires on ${format_date(object.fr_chorus_pwd_expiry_date)} (in <em>${ctx.get('pwd_days')}</em> days).</p>\n"
 "\n"
-"<p>The Odoo server of company <em>${object.name}</em> is setup to access the "
-"Chorus Pro API. Accessing the Chorus Pro API require both a technical user "
-"login/password and an RGS 1* certificate. Each of these 2 components have an "
-"expiry date. The expiry date of one of these components is imminent:</p>\n"
-"\n"
-"<ul>\n"
-"\n"
-"%if object.fr_chorus_pwd_expiry_date:\n"
-"<li>Technical user login/password: expire on ${object."
-"fr_chorus_pwd_expiry_date} (in <em>${ctx.get('pwd_days')})</em> days)</li>\n"
-"%endif\n"
-"\n"
-"%if object.fr_chorus_cert_expiry_date:\n"
-"<li>RGS 1* certificate: expire on ${object.fr_chorus_cert_expiry_date} (in "
-"<em>${ctx.get('cert_days')}</em> days)</li>\n"
-"%endif\n"
-"\n"
-"</ul>\n"
-"\n"
-"<p>Please take appropriate actions before the expiry date to ensure that "
-"Odoo will continue to access the Chorus Pro API without problems.</p>\n"
+"<p>In order to continue to access the Chorus Pro API without problems, you should connect to Chorus Pro, generate a new password for the technical user and copy it in Odoo on the accounting configuration page.</p>\n"
 "\n"
 "<p>\n"
 "-- <br/>\n"
 "Automatic e-mail sent by Odoo.\n"
 "</p>\n"
+""
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.invoice_form
-msgid "=> Update Chorus Invoice Status"
-msgstr "=> Mise à jour statut de la facture Chorus"
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_active
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__active
 msgid "Active"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:50
+#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:49
 #, python-format
 msgid "All the selected invoices must be in the same company"
 msgstr "Toutes les factures choisies doivent être de la même société"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
 msgid "Archived"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: selection:chorus.flow,syntax:0
-#: selection:res.company,fr_chorus_invoice_format:0
-#, fuzzy
-msgid "CII 16B XML"
-msgstr "CII 16B XML"
-
-#. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
 msgid "Cancel"
 msgstr "Annuler"
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:96
+#: code:addons/l10n_fr_chorus_account/models/partner.py:97
 #, python-format
 msgid "Cannot get Chorus Identifier on a contact (%s)"
 msgstr "Impossible de récupérer l'identifiant Chorus sur le contact (%s)"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.menu,name:l10n_fr_chorus_account.chorus_config
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.invoice_form
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.view_partner_property_form
-msgid "Chorus"
-msgstr "Chorus"
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model,name:l10n_fr_chorus_account.model_chorus_api
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.view_account_config_settings
-#: model:res.groups,name:l10n_fr_chorus_account.group_chorus_api
-msgid "Chorus API"
-msgstr "API Chorus"
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_cert_expiry_date
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_cert_expiry_date
-msgid "Chorus API Certificate Expiry Date"
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_check_commitment_number
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_check_commitment_number
+msgid "Check Commitment Numbers"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_api_login
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_api_login
-msgid "Chorus API Login"
-msgstr "Identifiant API Chorus"
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_api_password
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_api_password
-msgid "Chorus API Password"
-msgstr "Mot de passe API Chorus"
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_pwd_expiry_date
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_pwd_expiry_date
-#, fuzzy
-msgid "Chorus API Password Expiry Date"
-msgstr "Mot de passe API Chorus"
+#: model:res.groups,name:l10n_fr_chorus_account.group_chorus_api
+msgid "Chorus API"
+msgstr ""
 
 #. module: l10n_fr_chorus_account
 #: model:ir.model,name:l10n_fr_chorus_account.model_chorus_flow
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_flow_id
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice__chorus_flow_id
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
 msgid "Chorus Flow"
 msgstr "Flux Chorus"
 
 #. module: l10n_fr_chorus_account
 #: model:ir.actions.act_window,name:l10n_fr_chorus_account.chorus_flow_action
 #: model:ir.ui.menu,name:l10n_fr_chorus_account.chorus_flow_menu
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_tree
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_tree
 msgid "Chorus Flows"
 msgstr "Flux Chorus"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner_fr_chorus_identifier
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users_fr_chorus_identifier
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__chorus_identifier
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner__fr_chorus_identifier
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users__fr_chorus_identifier
 msgid "Chorus Identifier"
 msgstr "Identifiant Chorus"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_invoice_format
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_chorus_invoice_format
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_invoice_format
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__chorus_invoice_format
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_invoice_format
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_invoice_format
 msgid "Chorus Invoice Format"
 msgstr "Format de facture Chorus"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_identifier
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice__chorus_identifier
 msgid "Chorus Invoice Indentifier"
 msgstr "Identifiant de facture Chorus"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_status
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice__chorus_status
 msgid "Chorus Invoice Status"
 msgstr "Statut de facture Chorus"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_form
-#, fuzzy
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_form
 msgid "Chorus Partner Service"
 msgstr "Code du service Chorus"
 
 #. module: l10n_fr_chorus_account
 #: model:ir.actions.act_window,name:l10n_fr_chorus_account.chorus_partner_service_action
 #: model:ir.ui.menu,name:l10n_fr_chorus_account.chorus_partner_service_menu
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_tree
-#, fuzzy
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_tree
 msgid "Chorus Partner Services"
 msgstr "Code du service Chorus"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner_fr_chorus_service_id
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users_fr_chorus_service_id
-#, fuzzy
+#: model:ir.ui.menu,name:l10n_fr_chorus_account.chorus_config
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.invoice_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.res_config_settings_view_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.view_partner_form
+msgid "Chorus Pro"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.res_config_settings_view_form
+msgid "Chorus Pro API"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.actions.server,name:l10n_fr_chorus_account.chorus_api_expiry_reminder_cron_ir_actions_server
+#: model:ir.cron,cron_name:l10n_fr_chorus_account.chorus_api_expiry_reminder_cron
+#: model:ir.cron,name:l10n_fr_chorus_account.chorus_api_expiry_reminder_cron
+msgid "Chorus Pro API Expiry Reminder Email"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.actions.server,name:l10n_fr_chorus_account.chorus_flow_cron_ir_actions_server
+#: model:ir.cron,cron_name:l10n_fr_chorus_account.chorus_flow_cron
+#: model:ir.cron,name:l10n_fr_chorus_account.chorus_flow_cron
+msgid "Chorus Pro Invoice Status Update"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.actions.server,name:l10n_fr_chorus_account.chorus_partner_cron_ir_actions_server
+#: model:ir.cron,cron_name:l10n_fr_chorus_account.chorus_partner_cron
+#: model:ir.cron,name:l10n_fr_chorus_account.chorus_partner_cron
+msgid "Chorus Pro Partner Update"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner__fr_chorus_service_id
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users__fr_chorus_service_id
 msgid "Chorus Service"
 msgstr "Code du service Chorus"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.view_partner_property_form
-#, fuzzy
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner__fr_chorus_service_ids
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users__fr_chorus_service_ids
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.view_partner_form
 msgid "Chorus Services"
 msgstr "Code du service Chorus"
 
 #. module: l10n_fr_chorus_account
 #: model:ir.model,name:l10n_fr_chorus_account.model_chorus_partner_service
-#, fuzzy
 msgid "Chorus Services attached to a partner"
 msgstr "Code du service Chorus"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.view_account_invoice_filter
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.view_account_invoice_filter
 msgid "Chorus Status"
 msgstr "Statut Chorus"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_qualif
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_qualif
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_api_login
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_api_login
+msgid "Chorus Technical User Login"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_api_password
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_api_password
+msgid "Chorus Technical User Password"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_pwd_expiry_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_pwd_expiry_date
+msgid "Chorus Technical User Password Expiry Date"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_qualif
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_qualif
 msgid "Chorus Test Mode"
-msgstr "Mode de test Chorus"
+msgstr "Mode de Test Chorus"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_chorus_identifier
-#, fuzzy
-msgid "Chorus identifier"
-msgstr "Identifiant Chorus"
-
-#. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:112
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:125
 #, python-format
 msgid "Chorus only accepts IBAN. But the bank account '%s' is not an IBAN."
 msgstr ""
-"Chorus accepte seulement les IBAN. Mais le compte bancaire '%s' n'est pas un "
-"IBAN."
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:47
+#: code:addons/l10n_fr_chorus_account/models/partner.py:48
 #, python-format
-msgid ""
-"Chorus service codes can only be set on contacts, not on parent partners. "
-"Chorus service code '%s' has been set on partner %s that has no parent."
+msgid "Chorus service codes can only be set on contacts, not on parent partners. Chorus service code '%s' has been set on partner %s that has no parent."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
-#, fuzzy
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
 msgid "Code, Name or Identifier"
-msgstr "Identifiant Chorus"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:286
+#, python-format
+msgid "Commitment number '%s' not found in Chorus Pro. Please check the customer order reference carefully."
+msgstr ""
 
 #. module: l10n_fr_chorus_account
 #: model:ir.model,name:l10n_fr_chorus_account.model_res_company
@@ -244,66 +227,74 @@ msgid "Companies"
 msgstr "Sociétés"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_company_id
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_company_id
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__company_id
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__company_id
 msgid "Company"
 msgstr "Société"
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/chorus_api.py:36
+#: model:ir.model,name:l10n_fr_chorus_account.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/company.py:231
 #, python-format
-msgid ""
-"Connection to Chorus API (URL %s) failed. Check the Internet connection of "
-"the Odoo server.\n"
+msgid "Connection to Chorus API (URL %s) failed. Check the Internet connection of the Odoo server.\n"
 "\n"
 "Error details: %s"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:54
+#: code:addons/l10n_fr_chorus_account/models/company.py:150
 #, python-format
-msgid ""
-"Contacts with a Chorus service code should have a name. The Chorus service "
-"code '%s' has been set on a contact without a name."
+msgid "Connection to PISTE (URL %s) failed. Check the internet connection of the Odoo server.\n"
+"\n"
+"Error details: %s"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_create_uid
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_create_uid
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_create_uid
+#: model:ir.model,name:l10n_fr_chorus_account.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/partner.py:55
+#, python-format
+msgid "Contacts with a Chorus service code should have a name. The Chorus service code '%s' has been set on a contact without a name."
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__create_uid
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__create_uid
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__create_uid
 msgid "Created by"
 msgstr "Créé par"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_create_date
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_create_date
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_create_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__create_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__create_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__create_date
 msgid "Created on"
 msgstr "Créé le"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_partner_id
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__partner_id
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
 msgid "Customer"
 msgstr "Client"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
 msgid "Date"
 msgstr "Date"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_display_name
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_api_display_name
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_display_name
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_display_name
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__display_name
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__display_name
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__display_name
 msgid "Display Name"
 msgstr "Afficher le nom"
-
-#. module: l10n_fr_chorus_account
-#: selection:account.config.settings,group_chorus_api:0
-msgid "Do not use Chorus API"
-msgstr "Ne pas utiliser l'API Chorus"
 
 #. module: l10n_fr_chorus_account
 #: selection:res.partner,fr_chorus_required:0
@@ -311,65 +302,82 @@ msgid "Engagement"
 msgstr "Engagement"
 
 #. module: l10n_fr_chorus_account
-#: selection:chorus.flow,syntax:0
-#: selection:res.company,fr_chorus_invoice_format:0
-msgid "Factur-X PDF"
-msgstr "PDF Factur-X"
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__engagement_required
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
+msgid "Engagement Required"
+msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_attachment_id
+#: code:addons/l10n_fr_chorus_account/models/company.py:172
+#, python-format
+msgid "Error in the request to get a new token via PISTE.\n"
+"\n"
+"HTTP error code: %s. Error type: %s. Error description: %s."
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/company.py:163
+#, python-format
+msgid "Error in the request to get a new token via PISTE. HTTP error code: %s."
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__attachment_id
 msgid "File Sent to Chorus"
 msgstr "Fichier envoyé à Chorus"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__date
 msgid "Flow Date"
 msgstr "Date du flux"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_name
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__name
 msgid "Flow Ref"
 msgstr "Référence du flux"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_status
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__status
 msgid "Flow Status"
 msgstr "Statut du flux"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_syntax
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__syntax
 msgid "Flow Syntax"
 msgstr "Syntaxe du flux"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
 msgid "Get Chorus Invoice Identifiers"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
 msgid "Group By"
 msgstr "Grouper par"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_id
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_api_id
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_id
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_id
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__id
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__id
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__id
 msgid "ID"
 msgstr "ID"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_account_config_settings_group_chorus_api
-msgid ""
-"If you select 'Use Chorus API', it will add all users to the Chorus API "
-"group."
+#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_company__fr_chorus_check_commitment_number
+#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_check_commitment_number
+msgid "If enabled, Odoo will check the commitment number ('engagement juridique' in French) upon invoice validation. It corresponds to the 'customer order reference' in the administrative tongue. It will also check it upon sale order validation if the module l10n_fr_chorus_sale is installed."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner_fr_chorus_required
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users_fr_chorus_required
+#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_config_settings__group_chorus_api
+msgid "If you select 'Use Chorus Pro API', it will add all users to the Chorus API group."
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner__fr_chorus_required
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users__fr_chorus_required
 msgid "Info Required for Chorus"
 msgstr ""
 
@@ -379,242 +387,231 @@ msgid "Invoice"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:26
+#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:25
 #, python-format
-msgid ""
-"Invoice '%s' is a supplier invoice. You can only send customer invoices/"
-"refunds to Chorus."
+msgid "Invoice '%s' is a supplier invoice. You can only send customer invoices/refunds to Chorus."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_invoice_identifiers
-msgid "Invoice identifiers"
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__invoice_identifiers
+msgid "Invoice Identifiers"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_invoice_ids
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__invoice_ids
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
 msgid "Invoices"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_invoice_ids
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__invoice_ids
 msgid "Invoices to Send"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_status_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice__chorus_status_date
 msgid "Last Chorus Invoice Status Date"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send___last_update
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_api___last_update
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow___last_update
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service___last_update
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send____last_update
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow____last_update
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service____last_update
 msgid "Last Modified on"
 msgstr "Dernière Modification le"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_status_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__status_date
 msgid "Last Status Update"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_write_uid
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_write_uid
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_write_uid
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__write_uid
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__write_uid
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__write_uid
 msgid "Last Updated by"
-msgstr "Dernière modification par"
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_write_date
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_write_date
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_write_date
-msgid "Last Updated on"
-msgstr "Dernière modification le"
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_api_login
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_company_fr_chorus_api_login
-msgid "Login of the Technical User for Chorus API"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:140
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__write_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__write_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/company.py:108
 #, python-format
 msgid "Missing Chorus API parameters on the company %s"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:252
-#, fuzzy, python-format
+#: code:addons/l10n_fr_chorus_account/models/chorus_partner_service.py:112
+#: code:addons/l10n_fr_chorus_account/models/partner.py:185
+#: code:addons/l10n_fr_chorus_account/models/partner.py:263
+#, python-format
 msgid "Missing Chorus Identifier on partner %s."
-msgstr "Impossible de récupérer l'identifiant Chorus sur le contact (%s)"
+msgstr "Impossible de récupérer l'identifiant Chorus sur le contact %s"
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:176
-#, fuzzy, python-format
-msgid "Missing Chorus Identifier on partner '%s'."
-msgstr "Impossible de récupérer l'identifiant Chorus sur le contact (%s)"
+#: code:addons/l10n_fr_chorus_account/models/chorus_partner_service.py:100
+#, python-format
+msgid "Missing Chorus Identifier on service '%s' of partner '%s'."
+msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:191
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:204
 #, python-format
 msgid "Missing Chorus Invoice Identifier on invoice '%s'"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:262
+#: code:addons/l10n_fr_chorus_account/models/partner.py:273
 #, python-format
 msgid "Missing Info Required for Chorus on partner %s."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:90
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:103
 #, python-format
 msgid "Missing Payment Mode. This information is required for Chorus."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:106
+#: code:addons/l10n_fr_chorus_account/models/partner.py:107
 #, python-format
 msgid "Missing SIRET on partner %s"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:47
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:39
 #, python-format
-msgid ""
-"Missing SIRET on partner '%s'. This information is required for Chorus "
-"invoices."
+msgid "Missing SIRET on partner '%s' linked to company '%s'."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:101
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:50
 #, python-format
-msgid ""
-"Missing bank account information for payment. For that, you have two "
-"options: either the payment mode of the invoice should have 'Link to Bank "
-"Account' = 'fixed' and the related bank journal should have a 'Bank Account' "
-"set, or the field 'Bank Account' should be set on the customer invoice."
+msgid "Missing SIRET on partner '%s'. This information is required for Chorus invoices."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:50
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:114
 #, python-format
-msgid "Missing key 'chorus_api_cert' in Odoo server configuration file"
+msgid "Missing bank account information for payment. For that, you have two options: either the payment mode of the invoice should have 'Link to Bank Account' = 'fixed' and the related bank journal should have a 'Bank Account' set, or the field 'Bank Account' should be set on the customer invoice."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:70
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:242
 #, python-format
-msgid "Missing key 'chorus_api_key-%d' in Odoo server configuration file"
+msgid "Missing commitment number."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:140
+#: code:addons/l10n_fr_chorus_account/models/company.py:71
 #, python-format
-msgid ""
-"No entity found in Chorus corresponding to SIRET %s. The detailed error is "
-"written in Odoo server logs."
+msgid "Missing key 'chorus_api_oauth_id' in Odoo server configuration file"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:41
+#: code:addons/l10n_fr_chorus_account/models/company.py:80
+#, python-format
+msgid "Missing key 'chorus_api_oauth_secret' in Odoo server configuration file"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/partner.py:144
+#, python-format
+msgid "No entity found in Chorus corresponding to SIRET %s. The detailed error is written in Odoo server logs."
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:40
 #: selection:res.partner,fr_chorus_required:0
 #, python-format
 msgid "None"
 msgstr "Aucun"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_notes
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__notes
 msgid "Notes"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner_fr_chorus_service_count
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users_fr_chorus_service_count
-#, fuzzy
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner__fr_chorus_service_count
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users__fr_chorus_service_count
 msgid "Number of Chorus Services"
 msgstr "Code du service Chorus"
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_invoice_count
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__invoice_count
 msgid "Number of Invoices"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/chorus_flow.py:155
+#: code:addons/l10n_fr_chorus_account/models/chorus_flow.py:153
 #, python-format
 msgid "On flow %s, the status is not 'IN_INTEGRE'"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:36
+#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:35
 #, python-format
-msgid ""
-"On invoice '%s', the transmit method is '%s'. To be able to send it to "
-"Chorus, the transmit method must be 'Chorus'."
+msgid "On invoice '%s', the transmit method is '%s'. To be able to send it to Chorus, the transmit method must be 'Chorus'."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:115
+#: code:addons/l10n_fr_chorus_account/models/partner.py:118
 #, python-format
 msgid "On partner %s, the invoice transmit method is not set to Chorus"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model,name:l10n_fr_chorus_account.model_res_partner
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
 msgid "Partner"
 msgstr "Partenaire"
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:81
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:92
 #, python-format
-msgid ""
-"Partner '%s' is configured as 'Service or Engagement' required for Chorus "
-"but there is no engagement number in the field 'Reference/Description' and "
-"the customer of the invoice is not correctly configured as a service (should "
-"be a contact with a Chorus service and a name)."
+msgid "Partner '%s' is configured as 'Service or Engagement' required for Chorus but there is no engagement number in the field 'Reference/Description' and the customer of the invoice is not correctly configured as a service (should be a contact with a Chorus service and a name)."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:68
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:70
 #, python-format
-msgid ""
-"Partner '%s' is configured as Engagement required for Chorus, so the field "
-"'Reference/Description' must contain an engagement number."
+msgid "Partner '%s' is configured as Engagement required for Chorus, so the field 'Reference/Description' of its invoices must contain an engagement number."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
 #: code:addons/l10n_fr_chorus_account/models/account_invoice.py:58
 #, python-format
-msgid ""
-"Partner '%s' is configured as Service required for Chorus, so you must "
-"select a contact as customer for the invoice and this contact should have a "
-"name and a Chorus service and the Chorus service must be active."
+msgid "Partner '%s' is configured as Service required for Chorus, so you must select a contact as customer for the invoice and this contact should have a name and a Chorus service and the Chorus service must be active."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_api_password
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_company_fr_chorus_api_password
-msgid "Password of the Technical User for Chorus API"
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:81
+#, python-format
+msgid "Partner '%s' is linked to Chorus service '%s' which is marked as 'Engagement required', so the field 'Reference/Description' of its invoices must contain an engagement number."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
 msgid "Search Chorus Flows"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
 msgid "Search Partner Services"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.res_config_settings_view_form
+msgid "Send electronic invoices to the French administration directly from Odoo via the Chorus Pro API"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
 msgid "Send invoices to Chorus"
 msgstr ""
 
@@ -624,10 +621,14 @@ msgid "Send several invoices to Chorus"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.actions.act_window,name:l10n_fr_chorus_account.account_invoice_chorus_send_action
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.invoice_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.invoice_form
 msgid "Send to Chorus"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.actions.act_window,name:l10n_fr_chorus_account.account_invoice_chorus_send_action
+msgid "Send to Chorus Pro"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
@@ -636,13 +637,12 @@ msgid "Service"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_code
-#, fuzzy
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__code
 msgid "Service Code"
-msgstr "Code du service Chorus"
+msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_name
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__name
 msgid "Service Name"
 msgstr ""
 
@@ -657,82 +657,72 @@ msgid "Service or Engagement"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
 msgid "Status"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/chorus_api.py:42
+#: code:addons/l10n_fr_chorus_account/models/company.py:237
 #, python-format
-msgid ""
-"Technical failure when trying to connect to Chorus API.\n"
+msgid "Technical failure when trying to connect to Chorus API.\n"
 "\n"
 "Error details: %s"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:124
+#: code:addons/l10n_fr_chorus_account/models/company.py:156
 #, python-format
-msgid ""
-"The Chorus Invoice Format is not configured on the Accounting Configuration "
-"page of company '%s'"
+msgid "Technical failure when trying to get a new token from PISTE.\n"
+"\n"
+"Error details: %s"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/chorus_flow.py:165
+#: code:addons/l10n_fr_chorus_account/models/chorus_partner_service.py:35
+#, python-format
+msgid "The 'Service des factures publiques' with code 'FACTURES_PUBLIQUES' is dedicated to invoicing between public entities. Don't use it, otherwise the invoice will be rejected."
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:137
+#, python-format
+msgid "The Chorus Invoice Format is not configured on the Accounting Configuration page of company '%s'"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/chorus_flow.py:163
 #, python-format
 msgid "The Chorus Invoice Identifiers are already set for flow %s"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:62
+#: code:addons/l10n_fr_chorus_account/models/partner.py:63
 #, python-format
-msgid ""
-"The Chorus Service '%s' configured on contact '%s' is attached to another "
-"partner (%s)."
+msgid "The Chorus Service '%s' configured on contact '%s' is attached to another partner (%s)."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:60
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:257
 #, python-format
-msgid "The Chorus certificate file '%s' doesn't exist"
+msgid "The engagement juridique '%s' is %d caracters long. The maximum is 50. Please update the customer order reference."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:80
+#: code:addons/l10n_fr_chorus_account/models/company.py:120
 #, python-format
-msgid "The Chorus key file '%s' doesn't exist"
+msgid "The expiry date of the technical user password for Chorus API is %s. You should login to Chorus Pro, generate a new password for the technical user and update it in the menu Accounting > Configuration > Configuration."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:152
-#, python-format
-msgid ""
-"The expiry date of the certificate for Chorus API is %s. You should deploy a "
-"new certificate."
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:164
-#, python-format
-msgid ""
-"The expiry date of the technical user credentials for Chorus API is %s. You "
-"should login to Chorus Pro, generate new credentials for the technical user "
-"and update it in the menu Accounting > Configuration > Configuration."
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:43
+#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:42
 #, python-format
 msgid "The invoice '%s' has already been sent: it is linked to Chorus Flow %s."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:31
+#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:30
 #, python-format
-msgid ""
-"The state of invoice '%s' is '%s'. You can only send to Chorus invoices in "
-"open or paid state."
+msgid "The state of invoice '%s' is '%s'. You can only send to Chorus invoices in open or paid state."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
@@ -741,79 +731,55 @@ msgid "This Chorus service code already exists for that partner!"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
-msgid "This wizard will send electronic invoices to Chorus via the Chorus API."
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
+msgid "This wizard will send electronic invoices to Chorus Pro via the Chorus API."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: selection:chorus.flow,syntax:0
-#: selection:res.company,fr_chorus_invoice_format:0
-msgid "UBL XML"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:100
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:44
 #, python-format
-msgid "Unable to get the expiry date of the certificate %s. Error message: %s."
+msgid "Unece Due Date not configured on tax '%s'. This information is required for Chorus invoices."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:41
-#, python-format
-msgid ""
-"Unece Due Date not configured on tax '%s'. This information is required for "
-"Chorus invoices."
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.view_partner_form
+msgid "Update Chorus Info and Services"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.view_account_config_settings
-msgid "Update Certificate Expiry Date"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.invoice_form
+msgid "Update Chorus Invoice Status"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
 msgid "Update Flow Status"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.view_partner_property_form
-msgid "Update Info Required for Chorus"
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__group_chorus_api
+msgid "Use Chorus Pro API"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_group_chorus_api
-msgid "Use Chorus API"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: selection:account.config.settings,group_chorus_api:0
-msgid "Use Chorus API (requires RGS 1* certificate)"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_qualif
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_company_fr_chorus_qualif
+#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_company__fr_chorus_qualif
+#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_qualif
 msgid "Use the Chorus Pro qualification website"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_expiry_remind_user_ids
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_expiry_remind_user_ids
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_expiry_remind_user_ids
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_expiry_remind_user_ids
 msgid "Users Receiving the Expiry Reminder"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/chorus_api.py:49
+#: code:addons/l10n_fr_chorus_account/models/company.py:244
 #, python-format
 msgid "Wrong request on %s. HTTP error code received from Chorus: %s"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
 #: model:mail.template,subject:l10n_fr_chorus_account.chorus_api_expiry_reminder_mail_template
-msgid "[${object.name}] Chorus API credentials/certificate expiry"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model,name:l10n_fr_chorus_account.model_account_config_settings
-msgid "account.config.settings"
+msgid "[${object.name}] Action needed to continue to use the Chorus Pro API"
 msgstr ""

--- a/l10n_fr_chorus_account/i18n/l10n_fr_chorus_account.pot
+++ b/l10n_fr_chorus_account/i18n/l10n_fr_chorus_account.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-03-16 15:37+0000\n"
+"PO-Revision-Date: 2021-03-16 15:37+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,21 +18,9 @@ msgstr ""
 #. module: l10n_fr_chorus_account
 #: model:mail.template,body_html:l10n_fr_chorus_account.chorus_api_expiry_reminder_mail_template
 msgid "\n"
-"<p>The Odoo server of company <em>${object.name}</em> is setup to access the Chorus Pro API. Accessing the Chorus Pro API require both a technical user login/password and an RGS 1* certificate. Each of these 2 components have an expiry date. The expiry date of one of these components is imminent:</p>\n"
+"<p>The Odoo server of company <em>${object.name}</em> is configured to access the Chorus Pro API. Accessing the Chorus Pro API requires a technical user login and password. The password of the technical user has an expiry date. The password of the technical user expires on ${format_date(object.fr_chorus_pwd_expiry_date)} (in <em>${ctx.get('pwd_days')}</em> days).</p>\n"
 "\n"
-"<ul>\n"
-"\n"
-"%if object.fr_chorus_pwd_expiry_date:\n"
-"<li>Technical user login/password: expire on ${object.fr_chorus_pwd_expiry_date} (in <em>${ctx.get('pwd_days')})</em> days)</li>\n"
-"%endif\n"
-"\n"
-"%if object.fr_chorus_cert_expiry_date:\n"
-"<li>RGS 1* certificate: expire on ${object.fr_chorus_cert_expiry_date} (in <em>${ctx.get('cert_days')}</em> days)</li>\n"
-"%endif\n"
-"\n"
-"</ul>\n"
-"\n"
-"<p>Please take appropriate actions before the expiry date to ensure that Odoo will continue to access the Chorus Pro API without problems.</p>\n"
+"<p>In order to continue to access the Chorus Pro API without problems, you should connect to Chorus Pro, generate a new password for the technical user and copy it in Odoo on the accounting configuration page.</p>\n"
 "\n"
 "<p>\n"
 "-- <br/>\n"
@@ -40,138 +30,137 @@ msgid "\n"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.invoice_form
-msgid "=> Update Chorus Invoice Status"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_active
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__active
 msgid "Active"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:50
+#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:49
 #, python-format
 msgid "All the selected invoices must be in the same company"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
 msgid "Archived"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: selection:chorus.flow,syntax:0
-#: selection:res.company,fr_chorus_invoice_format:0
-msgid "CII 16B XML"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
 msgid "Cancel"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:96
+#: code:addons/l10n_fr_chorus_account/models/partner.py:97
 #, python-format
 msgid "Cannot get Chorus Identifier on a contact (%s)"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.menu,name:l10n_fr_chorus_account.chorus_config
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.invoice_form
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.view_partner_property_form
-msgid "Chorus"
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_check_commitment_number
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_check_commitment_number
+msgid "Check Commitment Numbers"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model,name:l10n_fr_chorus_account.model_chorus_api
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.view_account_config_settings
 #: model:res.groups,name:l10n_fr_chorus_account.group_chorus_api
 msgid "Chorus API"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_cert_expiry_date
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_cert_expiry_date
-msgid "Chorus API Certificate Expiry Date"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_api_login
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_api_login
-msgid "Chorus API Login"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_api_password
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_api_password
-msgid "Chorus API Password"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_pwd_expiry_date
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_pwd_expiry_date
-msgid "Chorus API Password Expiry Date"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
 #: model:ir.model,name:l10n_fr_chorus_account.model_chorus_flow
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_flow_id
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice__chorus_flow_id
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
 msgid "Chorus Flow"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
 #: model:ir.actions.act_window,name:l10n_fr_chorus_account.chorus_flow_action
 #: model:ir.ui.menu,name:l10n_fr_chorus_account.chorus_flow_menu
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_tree
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_tree
 msgid "Chorus Flows"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner_fr_chorus_identifier
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users_fr_chorus_identifier
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__chorus_identifier
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner__fr_chorus_identifier
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users__fr_chorus_identifier
 msgid "Chorus Identifier"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_invoice_format
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_chorus_invoice_format
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_invoice_format
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__chorus_invoice_format
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_invoice_format
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_invoice_format
 msgid "Chorus Invoice Format"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_identifier
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice__chorus_identifier
 msgid "Chorus Invoice Indentifier"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_status
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice__chorus_status
 msgid "Chorus Invoice Status"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_form
 msgid "Chorus Partner Service"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
 #: model:ir.actions.act_window,name:l10n_fr_chorus_account.chorus_partner_service_action
 #: model:ir.ui.menu,name:l10n_fr_chorus_account.chorus_partner_service_menu
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_tree
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_tree
 msgid "Chorus Partner Services"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner_fr_chorus_service_id
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users_fr_chorus_service_id
+#: model:ir.ui.menu,name:l10n_fr_chorus_account.chorus_config
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.invoice_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.res_config_settings_view_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.view_partner_form
+msgid "Chorus Pro"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.res_config_settings_view_form
+msgid "Chorus Pro API"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.actions.server,name:l10n_fr_chorus_account.chorus_api_expiry_reminder_cron_ir_actions_server
+#: model:ir.cron,cron_name:l10n_fr_chorus_account.chorus_api_expiry_reminder_cron
+#: model:ir.cron,name:l10n_fr_chorus_account.chorus_api_expiry_reminder_cron
+msgid "Chorus Pro API Expiry Reminder Email"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.actions.server,name:l10n_fr_chorus_account.chorus_flow_cron_ir_actions_server
+#: model:ir.cron,cron_name:l10n_fr_chorus_account.chorus_flow_cron
+#: model:ir.cron,name:l10n_fr_chorus_account.chorus_flow_cron
+msgid "Chorus Pro Invoice Status Update"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.actions.server,name:l10n_fr_chorus_account.chorus_partner_cron_ir_actions_server
+#: model:ir.cron,cron_name:l10n_fr_chorus_account.chorus_partner_cron
+#: model:ir.cron,name:l10n_fr_chorus_account.chorus_partner_cron
+msgid "Chorus Pro Partner Update"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner__fr_chorus_service_id
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users__fr_chorus_service_id
 msgid "Chorus Service"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.view_partner_property_form
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner__fr_chorus_service_ids
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users__fr_chorus_service_ids
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.view_partner_form
 msgid "Chorus Services"
 msgstr ""
 
@@ -181,36 +170,55 @@ msgid "Chorus Services attached to a partner"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.view_account_invoice_filter
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.view_account_invoice_filter
 msgid "Chorus Status"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_qualif
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_qualif
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_api_login
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_api_login
+msgid "Chorus Technical User Login"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_api_password
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_api_password
+msgid "Chorus Technical User Password"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_pwd_expiry_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_pwd_expiry_date
+msgid "Chorus Technical User Password Expiry Date"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_qualif
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_qualif
 msgid "Chorus Test Mode"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_chorus_identifier
-msgid "Chorus identifier"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:112
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:125
 #, python-format
 msgid "Chorus only accepts IBAN. But the bank account '%s' is not an IBAN."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:47
+#: code:addons/l10n_fr_chorus_account/models/partner.py:48
 #, python-format
 msgid "Chorus service codes can only be set on contacts, not on parent partners. Chorus service code '%s' has been set on partner %s that has no parent."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
 msgid "Code, Name or Identifier"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:286
+#, python-format
+msgid "Commitment number '%s' not found in Chorus Pro. Please check the customer order reference carefully."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
@@ -219,13 +227,18 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_company_id
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_company_id
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__company_id
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__company_id
 msgid "Company"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/chorus_api.py:36
+#: model:ir.model,name:l10n_fr_chorus_account.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/company.py:231
 #, python-format
 msgid "Connection to Chorus API (URL %s) failed. Check the Internet connection of the Odoo server.\n"
 "\n"
@@ -233,47 +246,54 @@ msgid "Connection to Chorus API (URL %s) failed. Check the Internet connection o
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:54
+#: code:addons/l10n_fr_chorus_account/models/company.py:150
+#, python-format
+msgid "Connection to PISTE (URL %s) failed. Check the internet connection of the Odoo server.\n"
+"\n"
+"Error details: %s"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model,name:l10n_fr_chorus_account.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/partner.py:55
 #, python-format
 msgid "Contacts with a Chorus service code should have a name. The Chorus service code '%s' has been set on a contact without a name."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_create_uid
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_create_uid
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_create_uid
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__create_uid
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__create_uid
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__create_uid
 msgid "Created by"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_create_date
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_create_date
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_create_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__create_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__create_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__create_date
 msgid "Created on"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_partner_id
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__partner_id
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
 msgid "Customer"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
 msgid "Date"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_display_name
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_api_display_name
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_display_name
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_display_name
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__display_name
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__display_name
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__display_name
 msgid "Display Name"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: selection:account.config.settings,group_chorus_api:0
-msgid "Do not use Chorus API"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
@@ -282,63 +302,82 @@ msgid "Engagement"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: selection:chorus.flow,syntax:0
-#: selection:res.company,fr_chorus_invoice_format:0
-msgid "Factur-X PDF"
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__engagement_required
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
+msgid "Engagement Required"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_attachment_id
+#: code:addons/l10n_fr_chorus_account/models/company.py:172
+#, python-format
+msgid "Error in the request to get a new token via PISTE.\n"
+"\n"
+"HTTP error code: %s. Error type: %s. Error description: %s."
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/company.py:163
+#, python-format
+msgid "Error in the request to get a new token via PISTE. HTTP error code: %s."
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__attachment_id
 msgid "File Sent to Chorus"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__date
 msgid "Flow Date"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_name
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__name
 msgid "Flow Ref"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_status
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__status
 msgid "Flow Status"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_syntax
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__syntax
 msgid "Flow Syntax"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
 msgid "Get Chorus Invoice Identifiers"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
 msgid "Group By"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_id
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_api_id
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_id
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_id
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__id
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__id
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__id
 msgid "ID"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_account_config_settings_group_chorus_api
-msgid "If you select 'Use Chorus API', it will add all users to the Chorus API group."
+#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_company__fr_chorus_check_commitment_number
+#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_check_commitment_number
+msgid "If enabled, Odoo will check the commitment number ('engagement juridique' in French) upon invoice validation. It corresponds to the 'customer order reference' in the administrative tongue. It will also check it upon sale order validation if the module l10n_fr_chorus_sale is installed."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner_fr_chorus_required
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users_fr_chorus_required
+#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_config_settings__group_chorus_api
+msgid "If you select 'Use Chorus Pro API', it will add all users to the Chorus API group."
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner__fr_chorus_required
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users__fr_chorus_required
 msgid "Info Required for Chorus"
 msgstr ""
 
@@ -348,194 +387,200 @@ msgid "Invoice"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:26
+#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:25
 #, python-format
 msgid "Invoice '%s' is a supplier invoice. You can only send customer invoices/refunds to Chorus."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_invoice_identifiers
-msgid "Invoice identifiers"
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__invoice_identifiers
+msgid "Invoice Identifiers"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_invoice_ids
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__invoice_ids
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
 msgid "Invoices"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_invoice_ids
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__invoice_ids
 msgid "Invoices to Send"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_status_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice__chorus_status_date
 msgid "Last Chorus Invoice Status Date"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send___last_update
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_api___last_update
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow___last_update
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service___last_update
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send____last_update
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow____last_update
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service____last_update
 msgid "Last Modified on"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_status_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__status_date
 msgid "Last Status Update"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_write_uid
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_write_uid
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_write_uid
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__write_uid
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__write_uid
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__write_uid
 msgid "Last Updated by"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_write_date
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_write_date
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_write_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__write_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__write_date
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__write_date
 msgid "Last Updated on"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_api_login
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_company_fr_chorus_api_login
-msgid "Login of the Technical User for Chorus API"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:140
+#: code:addons/l10n_fr_chorus_account/models/company.py:108
 #, python-format
 msgid "Missing Chorus API parameters on the company %s"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:252
+#: code:addons/l10n_fr_chorus_account/models/chorus_partner_service.py:112
+#: code:addons/l10n_fr_chorus_account/models/partner.py:185
+#: code:addons/l10n_fr_chorus_account/models/partner.py:263
 #, python-format
 msgid "Missing Chorus Identifier on partner %s."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:176
+#: code:addons/l10n_fr_chorus_account/models/chorus_partner_service.py:100
 #, python-format
-msgid "Missing Chorus Identifier on partner '%s'."
+msgid "Missing Chorus Identifier on service '%s' of partner '%s'."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:191
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:204
 #, python-format
 msgid "Missing Chorus Invoice Identifier on invoice '%s'"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:262
+#: code:addons/l10n_fr_chorus_account/models/partner.py:273
 #, python-format
 msgid "Missing Info Required for Chorus on partner %s."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:90
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:103
 #, python-format
 msgid "Missing Payment Mode. This information is required for Chorus."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:106
+#: code:addons/l10n_fr_chorus_account/models/partner.py:107
 #, python-format
 msgid "Missing SIRET on partner %s"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:47
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:39
+#, python-format
+msgid "Missing SIRET on partner '%s' linked to company '%s'."
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:50
 #, python-format
 msgid "Missing SIRET on partner '%s'. This information is required for Chorus invoices."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:101
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:114
 #, python-format
 msgid "Missing bank account information for payment. For that, you have two options: either the payment mode of the invoice should have 'Link to Bank Account' = 'fixed' and the related bank journal should have a 'Bank Account' set, or the field 'Bank Account' should be set on the customer invoice."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:50
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:242
 #, python-format
-msgid "Missing key 'chorus_api_cert' in Odoo server configuration file"
+msgid "Missing commitment number."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:70
+#: code:addons/l10n_fr_chorus_account/models/company.py:71
 #, python-format
-msgid "Missing key 'chorus_api_key-%d' in Odoo server configuration file"
+msgid "Missing key 'chorus_api_oauth_id' in Odoo server configuration file"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:140
+#: code:addons/l10n_fr_chorus_account/models/company.py:80
+#, python-format
+msgid "Missing key 'chorus_api_oauth_secret' in Odoo server configuration file"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/partner.py:144
 #, python-format
 msgid "No entity found in Chorus corresponding to SIRET %s. The detailed error is written in Odoo server logs."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:41
+#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:40
 #: selection:res.partner,fr_chorus_required:0
 #, python-format
 msgid "None"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow_notes
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_flow__notes
 msgid "Notes"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner_fr_chorus_service_count
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users_fr_chorus_service_count
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_partner__fr_chorus_service_count
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_users__fr_chorus_service_count
 msgid "Number of Chorus Services"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send_invoice_count
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_invoice_chorus_send__invoice_count
 msgid "Number of Invoices"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/chorus_flow.py:155
+#: code:addons/l10n_fr_chorus_account/models/chorus_flow.py:153
 #, python-format
 msgid "On flow %s, the status is not 'IN_INTEGRE'"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:36
+#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:35
 #, python-format
 msgid "On invoice '%s', the transmit method is '%s'. To be able to send it to Chorus, the transmit method must be 'Chorus'."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:115
+#: code:addons/l10n_fr_chorus_account/models/partner.py:118
 #, python-format
 msgid "On partner %s, the invoice transmit method is not set to Chorus"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model,name:l10n_fr_chorus_account.model_res_partner
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
 msgid "Partner"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:81
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:92
 #, python-format
 msgid "Partner '%s' is configured as 'Service or Engagement' required for Chorus but there is no engagement number in the field 'Reference/Description' and the customer of the invoice is not correctly configured as a service (should be a contact with a Chorus service and a name)."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:68
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:70
 #, python-format
-msgid "Partner '%s' is configured as Engagement required for Chorus, so the field 'Reference/Description' must contain an engagement number."
+msgid "Partner '%s' is configured as Engagement required for Chorus, so the field 'Reference/Description' of its invoices must contain an engagement number."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
@@ -545,23 +590,28 @@ msgid "Partner '%s' is configured as Service required for Chorus, so you must se
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_api_password
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_company_fr_chorus_api_password
-msgid "Password of the Technical User for Chorus API"
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:81
+#, python-format
+msgid "Partner '%s' is linked to Chorus service '%s' which is marked as 'Engagement required', so the field 'Reference/Description' of its invoices must contain an engagement number."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
 msgid "Search Chorus Flows"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_partner_service_search
 msgid "Search Partner Services"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.res_config_settings_view_form
+msgid "Send electronic invoices to the French administration directly from Odoo via the Chorus Pro API"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
 msgid "Send invoices to Chorus"
 msgstr ""
 
@@ -571,10 +621,14 @@ msgid "Send several invoices to Chorus"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.actions.act_window,name:l10n_fr_chorus_account.account_invoice_chorus_send_action
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.invoice_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.invoice_form
 msgid "Send to Chorus"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model:ir.actions.act_window,name:l10n_fr_chorus_account.account_invoice_chorus_send_action
+msgid "Send to Chorus Pro"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
@@ -583,12 +637,12 @@ msgid "Service"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_code
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__code
 msgid "Service Code"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service_name
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_chorus_partner_service__name
 msgid "Service Name"
 msgstr ""
 
@@ -603,12 +657,12 @@ msgid "Service or Engagement"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_search
 msgid "Status"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/chorus_api.py:42
+#: code:addons/l10n_fr_chorus_account/models/company.py:237
 #, python-format
 msgid "Technical failure when trying to connect to Chorus API.\n"
 "\n"
@@ -616,55 +670,57 @@ msgid "Technical failure when trying to connect to Chorus API.\n"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:124
+#: code:addons/l10n_fr_chorus_account/models/company.py:156
+#, python-format
+msgid "Technical failure when trying to get a new token from PISTE.\n"
+"\n"
+"Error details: %s"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/chorus_partner_service.py:35
+#, python-format
+msgid "The 'Service des factures publiques' with code 'FACTURES_PUBLIQUES' is dedicated to invoicing between public entities. Don't use it, otherwise the invoice will be rejected."
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:137
 #, python-format
 msgid "The Chorus Invoice Format is not configured on the Accounting Configuration page of company '%s'"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/chorus_flow.py:165
+#: code:addons/l10n_fr_chorus_account/models/chorus_flow.py:163
 #, python-format
 msgid "The Chorus Invoice Identifiers are already set for flow %s"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/partner.py:62
+#: code:addons/l10n_fr_chorus_account/models/partner.py:63
 #, python-format
 msgid "The Chorus Service '%s' configured on contact '%s' is attached to another partner (%s)."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:60
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:257
 #, python-format
-msgid "The Chorus certificate file '%s' doesn't exist"
+msgid "The engagement juridique '%s' is %d caracters long. The maximum is 50. Please update the customer order reference."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:80
+#: code:addons/l10n_fr_chorus_account/models/company.py:120
 #, python-format
-msgid "The Chorus key file '%s' doesn't exist"
+msgid "The expiry date of the technical user password for Chorus API is %s. You should login to Chorus Pro, generate a new password for the technical user and update it in the menu Accounting > Configuration > Configuration."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:152
-#, python-format
-msgid "The expiry date of the certificate for Chorus API is %s. You should deploy a new certificate."
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:164
-#, python-format
-msgid "The expiry date of the technical user credentials for Chorus API is %s. You should login to Chorus Pro, generate new credentials for the technical user and update it in the menu Accounting > Configuration > Configuration."
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:43
+#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:42
 #, python-format
 msgid "The invoice '%s' has already been sent: it is linked to Chorus Flow %s."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:31
+#: code:addons/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py:30
 #, python-format
 msgid "The state of invoice '%s' is '%s'. You can only send to Chorus invoices in open or paid state."
 msgstr ""
@@ -675,78 +731,55 @@ msgid "This Chorus service code already exists for that partner!"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
-msgid "This wizard will send electronic invoices to Chorus via the Chorus API."
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.account_invoice_chorus_send_form
+msgid "This wizard will send electronic invoices to Chorus Pro via the Chorus API."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: selection:chorus.flow,syntax:0
-#: selection:res.company,fr_chorus_invoice_format:0
-msgid "UBL XML"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/company.py:100
-#, python-format
-msgid "Unable to get the expiry date of the certificate %s. Error message: %s."
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:41
+#: code:addons/l10n_fr_chorus_account/models/account_invoice.py:44
 #, python-format
 msgid "Unece Due Date not configured on tax '%s'. This information is required for Chorus invoices."
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.view_account_config_settings
-msgid "Update Certificate Expiry Date"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.view_partner_form
+msgid "Update Chorus Info and Services"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.invoice_form
+msgid "Update Chorus Invoice Status"
+msgstr ""
+
+#. module: l10n_fr_chorus_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_chorus_account.chorus_flow_form
 msgid "Update Flow Status"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.ui.view,arch_db:l10n_fr_chorus_account.view_partner_property_form
-msgid "Update Info Required for Chorus"
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__group_chorus_api
+msgid "Use Chorus Pro API"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_group_chorus_api
-msgid "Use Chorus API"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: selection:account.config.settings,group_chorus_api:0
-msgid "Use Chorus API (requires RGS 1* certificate)"
-msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_qualif
-#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_company_fr_chorus_qualif
+#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_company__fr_chorus_qualif
+#: model:ir.model.fields,help:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_qualif
 msgid "Use the Chorus Pro qualification website"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_account_config_settings_fr_chorus_expiry_remind_user_ids
-#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company_fr_chorus_expiry_remind_user_ids
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_company__fr_chorus_expiry_remind_user_ids
+#: model:ir.model.fields,field_description:l10n_fr_chorus_account.field_res_config_settings__fr_chorus_expiry_remind_user_ids
 msgid "Users Receiving the Expiry Reminder"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
-#: code:addons/l10n_fr_chorus_account/models/chorus_api.py:49
+#: code:addons/l10n_fr_chorus_account/models/company.py:244
 #, python-format
 msgid "Wrong request on %s. HTTP error code received from Chorus: %s"
 msgstr ""
 
 #. module: l10n_fr_chorus_account
 #: model:mail.template,subject:l10n_fr_chorus_account.chorus_api_expiry_reminder_mail_template
-msgid "[${object.name}] Chorus API credentials/certificate expiry"
+msgid "[${object.name}] Action needed to continue to use the Chorus Pro API"
 msgstr ""
-
-#. module: l10n_fr_chorus_account
-#: model:ir.model,name:l10n_fr_chorus_account.model_account_config_settings
-msgid "account.config.settings"
-msgstr ""
-

--- a/l10n_fr_chorus_account/models/chorus_partner_service.py
+++ b/l10n_fr_chorus_account/models/chorus_partner_service.py
@@ -20,7 +20,7 @@ class ChorusPartnerService(models.Model):
     code = fields.Char(string='Service Code', required=True)
     active = fields.Boolean(default=True)
     name = fields.Char(string='Service Name')
-    chorus_identifier = fields.Integer(readonly=True)
+    chorus_identifier = fields.Integer(string='Chorus Identifier', readonly=True)
     engagement_required = fields.Boolean(string='Engagement Required')
 
     @api.constrains('code')

--- a/l10n_fr_chorus_account/models/partner.py
+++ b/l10n_fr_chorus_account/models/partner.py
@@ -183,7 +183,7 @@ class ResPartner(models.Model):
             if not partner.fr_chorus_identifier:
                 if raise_if_ko:
                     raise UserError(_(
-                        "Missing Chorus Identifier on partner '%s'.")
+                        "Missing Chorus Identifier on partner %s.")
                         % partner.display_name)
                 else:
                     logger.warning(


### PR DESCRIPTION
Start on a fresh database. Install l10n_fr_chorus_account. 
Try to load fr_FR (override existing terms): crash on duplicate translations.

It seems that the files are really out-of-date, so I would start from clean files. In that sense this PR is a WIP.
Also, it most probably affects all other languages.