### PR TITLE
[FIX] l10n_fr_hr_rup: remove super()._onchange_employee_id()

### DIFF
--- a/l10n_fr_hr_rup/models/hr_contract.py
+++ b/l10n_fr_hr_rup/models/hr_contract.py
@@ -7,14 +7,31 @@ class HrContract(models.Model):
     _inherit = "hr.contract"
     _order = "date_start,name"
 
-    pcs_id = fields.Many2one("hr.employee.pcs", "PCS")
     employer_address_id = fields.Many2one("res.partner", "Addresse de l'employeur")
-    qualification = fields.Char("Qualification")
-    work_location = fields.Char("Localisation du bureau")
+    pcs_id = fields.Many2one(
+        "hr.employee.pcs", "PCS", compute="_compute_pcs_id", store=True, readonly=False
+    )
+    qualification = fields.Char(
+        "Qualification", compute="_compute_qualification", store=True, readonly=False
+    )
+    work_location = fields.Char(
+        "Localisation du bureau",
+        compute="_compute_work_location",
+        store=True,
+        readonly=False,
+    )
 
-    @api.onchange("employee_id")
-    def _onchange_employee_id(self):
-        super()._onchange_employee_id()
-        self.pcs_id = self.employee_id.pcs_id
-        self.qualification = self.employee_id.qualification
-        self.work_location = self.employee_id.work_location
+    @api.depends("employee_id")
+    def _compute_pcs_id(self):
+        for rec in self:
+            rec.pcs_id = rec.employee_id.pcs_id
+
+    @api.depends("employee_id")
+    def _compute_qualification(self):
+        for rec in self:
+            rec.qualification = rec.employee_id.qualification
+
+    @api.depends("employee_id")
+    def _compute_work_location(self):
+        for rec in self:
+            rec.work_location = rec.employee_id.work_location


### PR DESCRIPTION
The native `_onchange_employee_id()` were converted to stored-editable computed fields in :
https://github.com/odoo/odoo/commit/3bd345597fa932abdaf780f72bacf331690f549b

cc @sebastienbeau @kevinkhao 