### PR TITLE
[REF][12.0] Fix Travis, ignoring modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
 env:
   global:
   - VERSION="12.0" TESTS="0" LINT_CHECK="0" MAKEPOT="0"
+  - EXCLUDE=l10n_fr_chorus_facturx,l10n_fr_chorus_ubl,l10n_fr_business_document_import,l10n_fr_chorus_account,l10n_fr_fec_oca,l10n_fr_chorus_sale
   matrix:
   - LINT_CHECK="1"
   - TESTS="1" ODOO_REPO="odoo/odoo" MAKEPOT="1"

--- a/l10n_fr_business_document_import/__manifest__.py
+++ b/l10n_fr_business_document_import/__manifest__.py
@@ -8,6 +8,7 @@
     'license': 'AGPL-3',
     'summary': 'Adapt the module base_business_document_import for France',
     'author': 'Akretion,Odoo Community Association (OCA)',
+    'development_status': 'Alpha',
     'website': 'https://github.com/OCA/l10n-france',
     'depends': ['l10n_fr_siret', 'base_business_document_import'],
     'installable': True,

--- a/l10n_fr_chorus_account/__manifest__.py
+++ b/l10n_fr_chorus_account/__manifest__.py
@@ -10,6 +10,7 @@
     'category': 'French Localization',
     'author': "Akretion,Odoo Community Association (OCA)",
     'maintainers': ['alexis-via'],
+    'development_status': 'Alpha',
     'website': 'https://github.com/OCA/l10n-france',
     'license': 'AGPL-3',
     'depends': [

--- a/l10n_fr_chorus_facturx/__manifest__.py
+++ b/l10n_fr_chorus_facturx/__manifest__.py
@@ -9,6 +9,7 @@
     'category': 'French Localization',
     'author': "Akretion,Odoo Community Association (OCA)",
     'maintainers': ['alexis-via'],
+    'development_status': 'Alpha',
     'website': 'https://github.com/OCA/l10n-france',
     'license': 'AGPL-3',
     'depends': [

--- a/l10n_fr_chorus_sale/__manifest__.py
+++ b/l10n_fr_chorus_sale/__manifest__.py
@@ -9,6 +9,7 @@
     'category': 'French Localization',
     'author': "Akretion,Odoo Community Association (OCA)",
     'maintainers': ['alexis-via'],
+    'development_status': 'Alpha',
     'website': 'https://github.com/OCA/l10n-france',
     'license': 'AGPL-3',
     'depends': [

--- a/l10n_fr_chorus_ubl/__manifest__.py
+++ b/l10n_fr_chorus_ubl/__manifest__.py
@@ -9,6 +9,7 @@
     'category': 'French Localization',
     'author': "Akretion,Odoo Community Association (OCA)",
     'maintainers': ['alexis-via'],
+    'development_status': 'Alpha',
     'website': 'https://github.com/OCA/l10n-france',
     'license': 'AGPL-3',
     'depends': [

--- a/l10n_fr_fec_oca/__manifest__.py
+++ b/l10n_fr_fec_oca/__manifest__.py
@@ -9,6 +9,7 @@
     "license": "LGPL-3",
     "summary": "Fichier d'Échange Informatisé (FEC) for France",
     "author": "Akretion,Odoo Community Association (OCA)",
+    "development_status": "Alpha",
     "website": "https://github.com/OCA/l10n-france",
     "depends": ["l10n_fr", "account", "date_range"],
     "external_dependencies": {


### PR DESCRIPTION
ignoring the following modules thats makes travis / runbot red on 12.0 branch :

- l10n_fr_chorus_facturx
- l10n_fr_chorus_ubl
- l10n_fr_business_document_import
- l10n_fr_chorus_account
- l10n_fr_fec_oca
- l10n_fr_chorus_sale
