### PR TITLE
[12.0] Restore tests and remove Alpha status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,11 @@ addons:
   apt:
     packages:
       - expect-dev  # provides unbuffer utility
-      - python-lxml  # because pip installation is slow
-      - python-simplejson
-      - python-serial
-      - python-yaml
+      - python3-oauthlib  # because pip installation is slow
 
 env:
   global:
   - VERSION="12.0" TESTS="0" LINT_CHECK="0" MAKEPOT="0"
-  - EXCLUDE=l10n_fr_chorus_facturx,l10n_fr_chorus_ubl,l10n_fr_business_document_import,l10n_fr_chorus_account,l10n_fr_fec_oca,l10n_fr_chorus_sale
   matrix:
   - LINT_CHECK="1"
   - TESTS="1" ODOO_REPO="odoo/odoo" MAKEPOT="1"

--- a/l10n_fr_business_document_import/__manifest__.py
+++ b/l10n_fr_business_document_import/__manifest__.py
@@ -8,7 +8,7 @@
     'license': 'AGPL-3',
     'summary': 'Adapt the module base_business_document_import for France',
     'author': 'Akretion,Odoo Community Association (OCA)',
-    'development_status': 'Alpha',
+    'maintainers': ['alexis-via'],
     'website': 'https://github.com/OCA/l10n-france',
     'depends': ['l10n_fr_siret', 'base_business_document_import'],
     'installable': True,

--- a/l10n_fr_business_document_import/tests/test_business_document_import.py
+++ b/l10n_fr_business_document_import/tests/test_business_document_import.py
@@ -20,7 +20,7 @@ class TestL10nFRBusinessDocumentImport(TransactionCase):
             'supplier': True,
             'is_company': True,
             'siren': '380129866',
-            'nic': '00010',
+            'nic': '00014',
             })
         bdio = self.env['business.document.import']
         partner_dict = {'siren': '380 129 866'}

--- a/l10n_fr_chorus_account/__manifest__.py
+++ b/l10n_fr_chorus_account/__manifest__.py
@@ -10,7 +10,6 @@
     'category': 'French Localization',
     'author': "Akretion,Odoo Community Association (OCA)",
     'maintainers': ['alexis-via'],
-    'development_status': 'Alpha',
     'website': 'https://github.com/OCA/l10n-france',
     'license': 'AGPL-3',
     'depends': [

--- a/l10n_fr_chorus_facturx/__manifest__.py
+++ b/l10n_fr_chorus_facturx/__manifest__.py
@@ -9,7 +9,6 @@
     'category': 'French Localization',
     'author': "Akretion,Odoo Community Association (OCA)",
     'maintainers': ['alexis-via'],
-    'development_status': 'Alpha',
     'website': 'https://github.com/OCA/l10n-france',
     'license': 'AGPL-3',
     'depends': [

--- a/l10n_fr_chorus_sale/__manifest__.py
+++ b/l10n_fr_chorus_sale/__manifest__.py
@@ -9,7 +9,6 @@
     'category': 'French Localization',
     'author': "Akretion,Odoo Community Association (OCA)",
     'maintainers': ['alexis-via'],
-    'development_status': 'Alpha',
     'website': 'https://github.com/OCA/l10n-france',
     'license': 'AGPL-3',
     'depends': [

--- a/l10n_fr_chorus_ubl/__manifest__.py
+++ b/l10n_fr_chorus_ubl/__manifest__.py
@@ -9,7 +9,6 @@
     'category': 'French Localization',
     'author': "Akretion,Odoo Community Association (OCA)",
     'maintainers': ['alexis-via'],
-    'development_status': 'Alpha',
     'website': 'https://github.com/OCA/l10n-france',
     'license': 'AGPL-3',
     'depends': [

--- a/l10n_fr_chorus_ubl/tests/test_chorus_ubl.py
+++ b/l10n_fr_chorus_ubl/tests/test_chorus_ubl.py
@@ -2,7 +2,7 @@
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.addons.account_payment_unece.tests.test_account_invoice import \
+from odoo.addons.account_tax_unece.tests.test_account_invoice import \
     TestAccountInvoice
 
 

--- a/l10n_fr_fec_oca/__manifest__.py
+++ b/l10n_fr_fec_oca/__manifest__.py
@@ -9,7 +9,6 @@
     "license": "LGPL-3",
     "summary": "Fichier d'Échange Informatisé (FEC) for France",
     "author": "Akretion,Odoo Community Association (OCA)",
-    "development_status": "Alpha",
     "website": "https://github.com/OCA/l10n-france",
     "depends": ["l10n_fr", "account", "date_range"],
     "external_dependencies": {

--- a/l10n_fr_fec_oca/wizard/account_fr_fec_oca.py
+++ b/l10n_fr_fec_oca/wizard/account_fr_fec_oca.py
@@ -3,6 +3,14 @@
 # Copyright 2016-2020 Odoo SA (https://www.odoo.com/fr_FR/)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+# This module is a fork of l10n_fr_fec from official addons
+# (which itself was copied from OCA with my authorisation)
+# The construction of SQL requests don't respect pylint E8103
+# The problem is that fixing this would require large changes in the code
+# which would make this module a deeper fork of l10n_fr_fec
+# and would make it more difficult to compare the 2 modules and port
+# changes/improvements between each other
+# pylint: skip-file
 
 import base64
 import io


### PR DESCRIPTION
This is the "real" work to make CI work on OCA/l10n-france. It aims at cancelling PR #297 . 

This PR also ends the humiliation of module authors/contributors who suddenly saw their modules flagged as Alpha software without notice with the mention in the README "This is an alpha version, the data model and design can change at any time without warning. Only for development or testing purpose, do not use in production." Humiliating module authors and contributors is not something we should tolerate in OCA/l10n-france. As PSC, I'll fight against this kind of attitude in OCA/l10n-france.