### PR TITLE
[14.0][FIX] partner nic validation when changing siren

### DIFF
--- a/l10n_fr_siret/models/res_partner.py
+++ b/l10n_fr_siret/models/res_partner.py
@@ -44,6 +44,8 @@ class Partner(models.Model):
     def _check_siret(self):
         """Check the SIREN's and NIC's keys (last digits)"""
         for rec in self:
+            if rec.type == "contact" and rec.parent_id:
+                continue
             if rec.nic:
                 # Check the NIC type and length
                 if not rec.nic.isdigit() or len(rec.nic) != 5:

--- a/l10n_fr_siret/tests/test_fr_siret.py
+++ b/l10n_fr_siret/tests/test_fr_siret.py
@@ -108,3 +108,32 @@ class TestL10nFrSiret(TransactionCase):
         self.assertFalse(partner_company2.same_siren_partner_id)
         partner_company2.write({"company_id": False})
         self.assertEqual(partner_company2.same_siren_partner_id, partner_company1)
+
+    def test_change_parent_id(self):
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Akretion France",
+                "siren": "792377731",
+                "nic": "00023",
+            }
+        )
+
+        partner2 = self.env["res.partner"].create(
+            {
+                "name": "Akretion Fr",
+                "siren": "784671695",
+                "nic": "00087",
+            }
+        )
+
+        contact = self.env["res.partner"].create(
+            {"name": "Test contact", "parent_id": partner.id}
+        )
+
+        self.assertEqual(partner.siren, contact.siren)
+        self.assertEqual(partner.nic, contact.nic)
+
+        contact.write({"parent_id": partner2.id})
+
+        self.assertEqual(partner2.siren, contact.siren)
+        self.assertEqual(partner2.nic, contact.nic)


### PR DESCRIPTION
When a contact is switching from a partner with siren and nic numbers, to another partner with different siren and nic numbers, validation of the siret failed (function  _check_siret). 

The Validation error is about the nic which is update after the siren. So the _check_siret() takes into account the new siren and the original nic, bringing an invalid checksum. 

I added the corresponding test and a working proposition to fix it. 