### PR TITLE
[12.0] DEB: adapt for January 1st 2022 reform

### DIFF
--- a/l10n_fr_intrastat_product/data/intrastat_transaction.xml
+++ b/l10n_fr_intrastat_product/data/intrastat_transaction.xml
@@ -13,7 +13,6 @@
     <field name="fr_object_type">in_invoice</field>
     <field name="fr_transaction_code">11</field>
     <field name="fr_is_fiscal_only" eval="False"/>
-    <field name="fr_is_vat_required" eval="False"/>
     <field name="fr_fiscal_value_multiplier">1</field>
     <field name="fr_intrastat_product_type">arrivals</field>
 </record>
@@ -24,7 +23,6 @@
     <field name="fr_object_type">out_invoice</field>
     <field name="fr_transaction_code">11</field>
     <field name="fr_is_fiscal_only" eval="False"/>
-    <field name="fr_is_vat_required" eval="True"/>
     <field name="fr_fiscal_value_multiplier">1</field>
     <field name="fr_intrastat_product_type">dispatches</field>
 </record>
@@ -34,7 +32,6 @@
     <field name="code">25</field>
     <field name="fr_object_type">out_refund</field>
     <field name="fr_is_fiscal_only" eval="True"/>
-    <field name="fr_is_vat_required" eval="True"/>
     <field name="fr_fiscal_value_multiplier">-1</field>
     <field name="fr_intrastat_product_type">dispatches</field>
 </record>

--- a/l10n_fr_intrastat_product/models/intrastat_product.py
+++ b/l10n_fr_intrastat_product/models/intrastat_product.py
@@ -62,10 +62,8 @@ class L10nFrIntrastatProductDeclaration(models.Model):
 
     @api.model
     def _get_product_origin_country(self, inv_line):
-        """Inherit to add warning when origin_country_id is missing
-        for arrivals"""
+        """Inherit to add warning when origin_country_id is missing"""
         if (
-                self.type == 'arrivals' and
                 self.reporting_level == 'extended' and
                 not inv_line.product_id.origin_country_id):
             note = "\n" + _(
@@ -246,7 +244,7 @@ class L10nFrIntrastatProductDeclaration(models.Model):
         assert self.reporting_level in ('standard', 'extended'),\
             "Invalid reporting level"
         if self.reporting_level == 'extended':
-            declaration_type_code.text = '1'
+            declaration_type_code.text = '5'  # DEB 2022: stat + fisc, 2 in 1 combo
         elif self.reporting_level == 'standard':
             declaration_type_code.text = '4'
         flow_code = etree.SubElement(declaration, 'flowCode')
@@ -297,9 +295,7 @@ class L10nFrIntrastatProductDeclaration(models.Model):
                     su_code.text = pline.intrastat_unit_id.fr_xml_label
                     destination_country = etree.SubElement(
                         item, 'MSConsDestCode')
-                    if self.type == 'arrivals':
-                        country_origin = etree.SubElement(
-                            item, 'countryOfOriginCode')
+                    country_origin = etree.SubElement(item, 'countryOfOriginCode')
                     weight = etree.SubElement(item, 'netMass')
                     quantity_in_SU = etree.SubElement(item, 'quantityInSU')
 
@@ -310,21 +306,18 @@ class L10nFrIntrastatProductDeclaration(models.Model):
                 else:
                     destination_country = etree.SubElement(
                         item, 'MSConsDestCode')
-                    if self.type == 'arrivals':
-                        country_origin = etree.SubElement(
-                            item, 'countryOfOriginCode')
+                    country_origin = etree.SubElement(item, 'countryOfOriginCode')
                     weight = etree.SubElement(item, 'netMass')
                 if not pline.src_dest_country_id:
                     raise UserError(_(
                         'Missing Country of Origin/Destination on line %d.')
                         % line)
                 destination_country.text = pline.src_dest_country_id.code
-                if self.type == 'arrivals':
-                    if not pline.product_origin_country_id:
-                        raise UserError(_(
-                            'Missing product country of origin on line %d.')
-                            % line)
-                    country_origin.text = pline.product_origin_country_id.code
+                # DEB 2022 : origin country is now for arrival AND dispatches
+                if not pline.product_origin_country_id:
+                    raise UserError(_(
+                        'Missing product country of origin on line %d.') % line)
+                country_origin.text = pline.product_origin_country_id.code
                 if not pline.weight:
                     raise UserError(
                         _('Missing weight on line %d.') % line)
@@ -336,10 +329,8 @@ class L10nFrIntrastatProductDeclaration(models.Model):
                 raise UserError(
                     _('Missing fiscal value on line %d.') % line)
             invoiced_amount.text = str(pline.amount_company_currency)
-            # Partner VAT is only declared for export when code régime != 29
-            if (
-                    self.type == 'dispatches' and
-                    transaction.fr_is_vat_required):
+            # DEB 2022 : Partner VAT now required for all dispatches
+            if self.type == 'dispatches':
                 partner_id = etree.SubElement(item, 'partnerId')
                 if not pline.fr_partner_id:
                     raise UserError(_(

--- a/l10n_fr_intrastat_product/models/intrastat_transaction.py
+++ b/l10n_fr_intrastat_product/models/intrastat_transaction.py
@@ -44,11 +44,6 @@ class IntrastatTransaction(models.Model):
         "'-1' for procedure code 25, '1' for all the others. "
         "This multiplier is used to compute the total fiscal value of "
         "the declaration.")
-    fr_is_vat_required = fields.Boolean(
-        string='Is partner VAT required?',
-        help="True for all procedure codes except 11, 19 and 29. "
-        "When False, the VAT number should not be filled in the "
-        "Intrastat product line.")
     # TODO : see with Luc if we can move it to intrastat_product
     fr_intrastat_product_type = fields.Selection([
         ('arrivals', 'Arrivals'),

--- a/l10n_fr_intrastat_product/views/intrastat_transaction.xml
+++ b/l10n_fr_intrastat_product/views/intrastat_transaction.xml
@@ -17,7 +17,6 @@
             <field name="fr_object_type" />
             <field name="fr_is_fiscal_only"/>
             <field name="fr_fiscal_value_multiplier" />
-            <field name="fr_is_vat_required" />
             <field name="fr_intrastat_product_type" />
         </field>
     </field>
@@ -33,7 +32,6 @@
             <field name="fr_object_type" />
             <field name="fr_is_fiscal_only"/>
             <field name="fr_fiscal_value_multiplier" />
-            <field name="fr_is_vat_required" />
             <field name="fr_intrastat_product_type" />
         </field>
     </field>


### PR DESCRIPTION
I propose that we DON'T merge this before January 10th 2022 (the reform starts on DEB of January 2022 that must be done in early February 2022).

Sources : https://www.douane.gouv.fr/sites/default/files/2021-10/18/Evolution-des-modalites-declaratives-DEB-1-janvier-2022.pdf
and https://www.douane.gouv.fr/sites/default/files/2021-10/18/DEBWEB2022-impacts-v.1.0_0.pdf