### PR TITLE
[FIX] company_registry : do not set company_registry field readonly on res.company model

### DIFF
--- a/l10n_fr_siret/models/company.py
+++ b/l10n_fr_siret/models/company.py
@@ -19,5 +19,8 @@ class ResCompany(models.Model):
         string='NIC', related='partner_id.nic', store=True, readonly=False)
     # company_registry field is definied in base module on res.company
     company_registry = fields.Char(
-        string='Company Registry', related='partner_id.company_registry',
-        store=True)
+        string='Company Registry',
+        related='partner_id.company_registry',
+        store=True,
+        readonly=False
+    )


### PR DESCRIPTION
Trivial patch.

the module ``l10n_fr_siret`` introduce a field ``company_registry`` field on ``res.partner`` and set the existing ``res.company`` field related to it. but the field is readonly on the company form.

this PR fixes this problem.

Note : this problem has been fixed upstream. see : https://github.com/OCA/l10n-france/blob/14.0/l10n_fr_siret/models/res_company.py#L22

CC : authors / contributors : @alexis-via, @fmdl, @zuher83, @remi-filament, @Kev-Roche 

GRAP : n°292 CC / @quentinDupont 
