### PR TITLE
[IMP] l10n_fr_department: replace departament_id before country_id

### DIFF
--- a/l10n_fr_department/view/res_partner.xml
+++ b/l10n_fr_department/view/res_partner.xml
@@ -23,14 +23,22 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <field name="state_id" position="before">
-                <field name="department_id" class="o_address_state" />
+            <field name="country_id" position="before">
+                <field
+                    name="department_id"
+                    class="o_address_country"
+                    attrs="{'invisible': [('department_id', '=', False)]}"
+                />
             </field>
             <xpath
-                expr="//field[@name='child_ids']/form//field[@name='state_id']"
+                expr="//field[@name='child_ids']/form//field[@name='country_id']"
                 position="before"
             >
-                <field name="department_id" class="o_address_state" />
+                <field
+                    name="department_id"
+                    class="o_address_country"
+                    attrs="{'invisible': [('department_id', '=', False)]}"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
@legalsylvain This makes partner form look even better.
1. Separate line before country to avoid zip field to be moved to a new line.
2. Show department only for French companies.
![before_country](https://user-images.githubusercontent.com/29202630/159129115-4fc480cd-9479-4769-a4d4-ee1e99e61e41.png)

