### PR TITLE
[12.0] Fix PyPDF2 version to <2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ requests_oauthlib
 unicodecsv
 unidecode   
 ofxparse
-PyPDF2=1.*
+PyPDF2<2.0
 factur-x

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ requests_oauthlib
 unicodecsv
 unidecode   
 ofxparse
-PyPDF2
+PyPDF2=1.*
 factur-x


### PR DESCRIPTION
Fix PyPDF2 version to<2.0 since version 2 is incompatible with odoo 12.0