### PR TITLE
[14.0] l10n_fr_department: excludes module partner_contact_department

### DIFF
--- a/l10n_fr_department/__manifest__.py
+++ b/l10n_fr_department/__manifest__.py
@@ -19,6 +19,8 @@
         "l10n_fr_state",
         "contacts",
     ],
+    "excludes": ["partner_contact_department"],
+    # partner_contact_department also declares a field 'department_id' on res.partner
     "data": [
         "security/ir.model.access.csv",
         "data/res_country_department.xml",


### PR DESCRIPTION
Following bug https://github.com/OCA/l10n-france/issues/384
partner_contact_department also has a field "department_id" on res.partner :-(