### PR TITLE
automatically remove payment_mode_id on refund

### DIFF
--- a/l10n_fr_chorus_account/models/account_invoice.py
+++ b/l10n_fr_chorus_account/models/account_invoice.py
@@ -308,3 +308,5 @@ class AccountInvoice(models.Model):
                 invoice.type == 'out_invoice' and 
                 invoice.transmit_method_code == 'fr-chorus'):
             values["payment_mode_id"] = False
+        return values
+    

--- a/l10n_fr_chorus_account/models/account_invoice.py
+++ b/l10n_fr_chorus_account/models/account_invoice.py
@@ -296,3 +296,15 @@ class AccountInvoice(models.Model):
         logger.warning(
             'Commitment number %s not found in Chorus Pro.', order_ref)
         return False
+    
+    @api.model
+    def _prepare_refund(
+        self, invoice, date_invoice=None, date=None, description=None, journal_id=None
+    ):
+        values = super(AccountInvoice, self)._prepare_refund(
+            invoice, date_invoice, date, description, journal_id
+        )
+        if (
+                invoice.type == 'out_invoice' and 
+                invoice.transmit_method_code == 'fr-chorus'):
+            values["payment_mode_id"] = False


### PR DESCRIPTION
Since payment_mode_id must be empty on refund with transmit_method_code == "fr-chorus", if we try to create a refund with the account.invoice.refund wizard and filter_refund set to cancel or modify that auto validate the refund we get the error ''The Payment Mode must be empty for customer refunds sent to Chorus." I suggest to remove it in _prepare_refund to avoid to get this error and allow us to use the wizard normally.