### PR TITLE
[15.0][IMP] l10n_fr_department: improve performances

### DIFF
--- a/l10n_fr_department/model/res_partner.py
+++ b/l10n_fr_department/model/res_partner.py
@@ -3,6 +3,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
+from odoo.tools.cache import ormcache
+from odoo.tools.misc import groupby
 
 
 class ResPartner(models.Model):
@@ -18,33 +20,55 @@ class ResPartner(models.Model):
     @api.depends("zip", "country_id", "country_id.code")
     # If a department code changes, it will have to be manually recomputed
     def _compute_department(self):
-        rcdo = self.env["res.country.department"]
-        fr_country_ids = (
-            self.env["res.country"]
-            .search([("code", "in", ("FR", "GP", "MQ", "GF", "RE", "YT"))])
-            .ids
-        )
-        for partner in self:
-            dpt_id = False
-            zipcode = partner.zip
-            if (
-                partner.country_id
-                and partner.country_id.id in fr_country_ids
-                and zipcode
-                and len(zipcode) == 5
-            ):
-                zipcode = partner.zip.strip().replace(" ", "").rjust(5, "0")
-                code = self._fr_zipcode_to_department_code(zipcode)
-                dpt = rcdo.search(
-                    [
-                        ("code", "=", code),
-                        ("country_id", "in", fr_country_ids),
-                    ],
-                    limit=1,
-                )
-                dpt_id = dpt and dpt.id or False
-            partner.department_id = dpt_id
+        def _get_zipcode(partner) -> str:
+            if partner.country_id not in fr_countries:
+                return ""
+            partner_zip = partner.zip
+            if not partner_zip:
+                return ""
+            partner_zip = partner_zip.strip().replace(" ", "").rjust(5, "0")
+            return partner_zip if len(partner_zip) == 5 else ""
 
+        fr_countries_codes = ("FR", "GP", "MQ", "GF", "RE", "YT")
+        fr_countries_domain = [("code", "in", fr_countries_codes)]
+        fr_countries = self.env["res.country"].search(fr_countries_domain)
+
+        # Group partners by zip code
+        partners_by_zipcode = dict(groupby(self, key=_get_zipcode))
+
+        # Retrieve all available departments by normalized department zip code
+        department_obj = self.env["res.country.department"]
+        zip2dep = self._fr_zipcode_to_department_code
+        department_codes = {zip2dep(c) for c in partners_by_zipcode if c}
+        departments = department_obj
+        if department_codes:
+            departments_domain = [
+                ("code", "in", tuple(department_codes)),
+                ("country_id", "in", fr_countries.ids),
+            ]
+            departments = department_obj.search(departments_domain)
+
+        # Shortcut: if no department is set for the given zip codes, make a
+        # single assignment for the whole recordset with the null value (this
+        # will surely happen the first time the module is installed: field is
+        # computed before loading ``res.country.department`` records via
+        # .xml file)
+        if not departments:
+            self.department_id = False
+        # Else: group departments by zip code, assign them to the grouped
+        # partners according to their common zip code
+        else:
+            departments_by_code = dict(groupby(departments, key=lambda d: d.code))
+            for zipcode, partner_list in partners_by_zipcode.items():
+                department = department_obj
+                if zipcode:
+                    dep_code = zip2dep(zipcode)
+                    if dep_code in departments_by_code:
+                        department = departments_by_code[dep_code][0]
+                self.browse().concat(*partner_list).department_id = department
+
+    @api.model
+    @ormcache("zipcode")
     def _fr_zipcode_to_department_code(self, zipcode):
         code = zipcode[0:2]
         # https://fr.wikipedia.org/wiki/Liste_des_communes_de_France_dont_le_code_postal_ne_correspond_pas_au_d%C3%A9partement  # noqa


### PR DESCRIPTION
On install, ``_compute_department()`` method is triggered by the `post-init-hook` on every existing French partners, archived ones as well. This commit tries to improve performances by grouping partners by zipcode (if valid) to avoid huge loading times when installing the module.

Tested on a DB where recomputation was triggered on >75k records by the ``post-init-hook``: install time dropped from >60mins to ~2.5mins.

Edit: down to ~2.0mins after @ivantodorovich suggestions. 