### PR TITLE
[14.0][FIX] l10n_fr_hr_rup: checksum-valid SSNID in demo data

### DIFF
--- a/l10n_fr_hr_rup/demo/demo.xml
+++ b/l10n_fr_hr_rup/demo/demo.xml
@@ -99,7 +99,7 @@
             />
             <field name="gender">male</field>
             <field name="country_id" ref="base.fr" />
-            <field name="ssnid">195109912611151</field>
+            <field name="ssnid">195109912611146</field>
             <field name="address_home_id" ref="base.res_partner_2" />
             <field name="qualification">Partenaire</field>
             <field name="pcs_id" ref="hr_employee_pcs_cadre" />
@@ -112,7 +112,7 @@
             />
             <field name="gender">male</field>
             <field name="country_id" ref="base.fr" />
-            <field name="ssnid">195109912611252</field>
+            <field name="ssnid">195109912622232</field>
             <field name="address_home_id" ref="base.res_partner_3" />
             <field name="qualification">Médior</field>
             <field name="pcs_id" ref="hr_employee_pcs_cadre" />
@@ -125,7 +125,7 @@
             />
             <field name="gender">male</field>
             <field name="country_id" ref="base.fr" />
-            <field name="ssnid">195109912617215</field>
+            <field name="ssnid">195109912633318</field>
             <field name="address_home_id" ref="base.res_partner_4" />
             <field name="qualification">Sénior</field>
             <field name="pcs_id" ref="hr_employee_pcs_intermediaires" />


### PR DESCRIPTION
The module l10n_fr_hr_rup depends on l10n_fr_hr_check_ssnid, so it must supply checksum-valid social security number as demo data, otherwise the installation of the module fails!