### PR TITLE
[14.0][FIX] l10n_fr_account_vat_return: fix reconciliation

### DIFF
--- a/l10n_fr_account_vat_return/models/l10n_fr_account_vat_return.py
+++ b/l10n_fr_account_vat_return/models/l10n_fr_account_vat_return.py
@@ -1844,6 +1844,7 @@ class L10nFrAccountVatReturn(models.Model):
             # when the moves are already reconciled
             if rg_res and speedy["currency"].is_zero(rg_res[0]["balance"] or 0):
                 moves_to_reconcile = speedy["aml_obj"].search(domain)
+                moves_to_reconcile.remove_move_reconcile()
                 moves_to_reconcile.reconcile()
 
     def _create_draft_account_move(self, speedy):


### PR DESCRIPTION
Before reconciliation, we need to remove partial reconcile otherwise we have an error message which says that the moves are already reconciled.