### PR TITLE
[REF] copier update v1.14.2

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.14.1
+_commit: v1.14.2
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.5.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort except __init__.py


### PR DESCRIPTION
Hi @alexis-via.

This should CI problem mentionned here :  https://github.com/OCA/l10n-france/pull/421

```
git checkout 14.0
git checkout -b 14.0-fix-copier
copier update
git push your_remote 14.0-fix-copier
```

Generaly, if CI breaks, you can check issues / PR on this project. https://github.com/OCA/oca-addons-repo-template/

Here is the bug in question : https://github.com/OCA/oca-addons-repo-template/pull/184