### PR TITLE
[16.0][IMP] account_statement_import_fr_cfonb: add small hook to allow to a…

### DIFF
--- a/account_statement_import_fr_cfonb/wizard/account_statement_import.py
+++ b/account_statement_import_fr_cfonb/wizard/account_statement_import.py
@@ -18,6 +18,10 @@ class AccountStatementImport(models.TransientModel):
 
     _excluded_accounts = []
 
+    @api.model
+    def _get_allow_cfonb_complementary_types(self):
+        return ("   ", "LIB", "LCC", "RCN")
+
     def _parse_cfonb_amount(self, amount_str, nb_of_dec):
         """Taken from the cfonb lib"""
         if nb_of_dec:
@@ -156,7 +160,8 @@ class AccountStatementImport(models.TransientModel):
                 # too long labels with too much "pollution"
                 transactions[-1]["unique_import_id"] += complementary_info
                 if (
-                    complementary_info_type in ("   ", "LIB", "LCC")
+                    complementary_info_type
+                    in self._get_allow_cfonb_complementary_types()
                     and complementary_info
                 ):
                     transactions[-1]["payment_ref"] += " " + complementary_info


### PR DESCRIPTION
…dd more info in label

@alexis-via 
As you know, I have already added back some complementary label in the module, but it is still not enough.
I have BNP Cfonb files that add the sale order reference in the RCN category (in case of customer bank transfer payment)
In other cases, the information is useless indeed, but it is impossible not to have it in some other case...

So, in order to not pollute people that don't need it, I propose this small hook that allow to add some complementary code at demand.
What do you think ?