### PR TITLE
[IMP] l10n_fr_department : if country is not defined on partner, use the country of the company of the partner, to guess the department

### DIFF
--- a/l10n_fr_department/model/res_partner.py
+++ b/l10n_fr_department/model/res_partner.py
@@ -8,7 +8,7 @@ from odoo import models, fields, api
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    @api.depends('zip', 'country_id', 'country_id.code')
+    @api.depends('zip', 'country_id', 'country_id.code', "company_id.country_id")
     # If a department code changes, it will have to be manually recomputed
     def _compute_department(self):
         rcdo = self.env['res.country.department']
@@ -16,10 +16,13 @@ class ResPartner(models.Model):
             ('code', 'in', ('FR', 'GP', 'MQ', 'GF', 'RE', 'YT'))]).ids
         for partner in self:
             dpt_id = False
+            country = partner.country_id or (
+                partner.company_id and partner.company_id.country_id
+            ) or False
             zipcode = partner.zip
             if (
-                    partner.country_id and
-                    partner.country_id.id in fr_country_ids and
+                    country and
+                    country.id in fr_country_ids and
                     zipcode and
                     len(zipcode) == 5):
                 zipcode = partner.zip.strip().replace(' ', '').rjust(5, '0')

--- a/l10n_fr_department/tests/test_department.py
+++ b/l10n_fr_department/tests/test_department.py
@@ -8,6 +8,9 @@ from odoo.tests.common import TransactionCase
 class TestFrDepartment(TransactionCase):
 
     def test_fr_department(self):
+        main_company = self.env.ref("base.main_company")
+        main_company.country_id = False
+
         rpo = self.env['res.partner']
         partner1 = rpo.create({
             'name': 'Akretion France',
@@ -15,6 +18,7 @@ class TestFrDepartment(TransactionCase):
             'zip': '69100',
             'city': 'Villeurbanne',
             'country_id': self.env.ref('base.fr').id,
+            'company_id': main_company.id,
         })
         self.assertEqual(
             partner1.department_id,
@@ -25,7 +29,20 @@ class TestFrDepartment(TransactionCase):
             'zip': '84330',
             'city': 'Le Barroux',
             'country_id': self.env.ref('base.fr').id,
+            'company_id': main_company.id,
         })
+        self.assertEqual(
+            partner2.department_id,
+            self.env.ref('l10n_fr_department.res_country_department_vaucluse'))
+
+        # Check if country is not defined on partner nor company
+        partner2.country_id = False
+        self.assertEqual(
+            partner2.department_id.id,
+            False)
+
+        # Check if country is not defined on partner but on company
+        main_company.country_id = self.env.ref('base.fr')
         self.assertEqual(
             partner2.department_id,
             self.env.ref('l10n_fr_department.res_country_department_vaucluse'))


### PR DESCRIPTION
@alexis-via : could you take a look on this trivial one ?

context : a lot of partner has no country defined. Some department computation is not done. However, we can assume that the country is the country of the current company of the partner.


Thanks !