### PR TITLE
[12.0][BKP] l10n_fr_fec_oca: backport of 14.0 fix

### DIFF
--- a/l10n_fr_fec_oca/wizard/account_fr_fec_oca.py
+++ b/l10n_fr_fec_oca/wizard/account_fr_fec_oca.py
@@ -59,7 +59,7 @@ class AccountFrFecOca(models.TransientModel):
     partner_account_ids = fields.Many2many(
         'account.account', string='Accounts',
         default=lambda self: self._default_partner_account_ids())
-    fec_data = fields.Binary('FEC File', readonly=True)
+    fec_data = fields.Binary('FEC File', readonly=True, attachment=True)
     filename = fields.Char(string='Filename', size=256, readonly=True)
     export_type = fields.Selection([
         ('official', 'Official FEC report (posted entries only)'),


### PR DESCRIPTION
- An important fix for big dbs was introduced during migration of `l10n_fr_fec_oca` to 14.0: https://github.com/OCA/l10n-france/commit/bf137b744a10d2440c76c679f7978de803ba91e8
- Meanwhile `l10n_fr_fec` was also fixed for versions 13.0 and above, see https://github.com/odoo/odoo/pull/80596
- Note that before Odoo 13.0, binary fields defaulted to `attachment=False`, see [66f0e2](https://github.com/odoo/odoo/commit/66f0e26f6f3f2155fcfcc55e84f2e76cbfdb2c1d), which is why fix in 12.0 needs an explicit `attachment=True`
