### PR TITLE
[FIX] vat_return: fix crash in another very specific scenario

### DIFF
--- a/l10n_fr_account_vat_return/models/l10n_fr_account_vat_return.py
+++ b/l10n_fr_account_vat_return/models/l10n_fr_account_vat_return.py
@@ -1888,6 +1888,7 @@ class L10nFrAccountVatReturn(models.Model):
             account = line.account_id
             domain = speedy["base_domain_end"] + [
                 ("account_id", "=", account.id),
+                ("reconciled", "=", False),
                 ("full_reconcile_id", "=", False),
                 ("move_id", "not in", excluded_line_ids),
             ]


### PR DESCRIPTION
We add trouble with a old account.move.line where debit = 0 and credit = 0 so reconciled was "true" : it was blocking vat reconcilement, we figured out with @alexis-via where was the issue 