### PR TITLE
[IMP] account_banking_fr_lcr: add posibility to disable CRLF within generated CFONB files

### DIFF
--- a/account_banking_fr_lcr/README.rst
+++ b/account_banking_fr_lcr/README.rst
@@ -52,6 +52,9 @@ To configure this module, you need to create a new payment mode linked
 to the payment method *Lettre de Change Relevé* that is automatically
 created when you install this module.
 
+Optionnally: within this payment method, 
+you have the possibility to disable addition of CRLF in generated files.
+
 Usage
 =====
 

--- a/account_banking_fr_lcr/__manifest__.py
+++ b/account_banking_fr_lcr/__manifest__.py
@@ -14,7 +14,10 @@
     "category": "French localisation",
     "depends": ["account_payment_order"],
     "external_dependencies": {"python": ["unidecode"]},
-    "data": ["data/account_payment_method.xml"],
+    "data": [
+        "data/account_payment_method.xml",
+        "views/account_payment_order.xml",
+    ],
     "demo": ["demo/lcr_demo.xml"],
     "post_init_hook": "lcr_set_unece",
     "installable": True,

--- a/account_banking_fr_lcr/models/account_payment_method.py
+++ b/account_banking_fr_lcr/models/account_payment_method.py
@@ -2,11 +2,19 @@
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class AccountPaymentMethod(models.Model):
     _inherit = "account.payment.method"
+
+    fr_lcr_use_crlf = fields.Boolean(
+        string="Use CRLF in generated CFONB file",
+        help="""Enable usage of CRLF ('\\r\\n') within generated CFONB files.
+        Only used for  creation of French LCR CFONB fileds.
+        [By default: True]""",
+        default=True,
+    )
 
     @api.model
     def _get_payment_method_information(self):

--- a/account_banking_fr_lcr/models/account_payment_order.py
+++ b/account_banking_fr_lcr/models/account_payment_order.py
@@ -152,7 +152,8 @@ class AccountPaymentOrder(models.Model):
             ]
         )
         assert len(cfonb_line) == 160, "LCR CFONB line must have 160 chars"
-        cfonb_line += "\r\n"
+        if self.payment_method_id.fr_lcr_use_crlf:
+            cfonb_line += "\r\n"
         return cfonb_line
 
     @api.model
@@ -206,7 +207,8 @@ class AccountPaymentOrder(models.Model):
             ]
         )
         assert len(cfonb_line) == 160, "LCR CFONB line must have 160 chars"
-        cfonb_line += "\r\n"
+        if self.payment_method_id.fr_lcr_use_crlf:
+            cfonb_line += "\r\n"
         return cfonb_line
 
     def _prepare_final_cfonb_line(self, total_amount, transactions_count):

--- a/account_banking_fr_lcr/readme/CONFIGURE.rst
+++ b/account_banking_fr_lcr/readme/CONFIGURE.rst
@@ -1,3 +1,6 @@
 To configure this module, you need to create a new payment mode linked
 to the payment method *Lettre de Change Relevé* that is automatically
 created when you install this module.
+
+Optionnally: within this payment method, 
+you have the possibility to disable addition of CRLF in generated files.

--- a/account_banking_fr_lcr/static/description/index.html
+++ b/account_banking_fr_lcr/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -398,6 +398,8 @@ planned date.</p>
 <p>To configure this module, you need to create a new payment mode linked
 to the payment method <em>Lettre de Change Relevé</em> that is automatically
 created when you install this module.</p>
+<p>Optionnally: within this payment method,
+you have the possibility to disable addition of CRLF in generated files.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
@@ -429,7 +431,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_banking_fr_lcr/views/account_payment_order.xml
+++ b/account_banking_fr_lcr/views/account_payment_order.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 ACSONE SA/NV
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record model="ir.ui.view" id="account_payment_method_form_view">
+        <field
+            name="name"
+        >account.payment.method.form (in account_banking_fr_lcr)</field>
+        <field name="model">account.payment.method</field>
+        <field
+            name="inherit_id"
+            ref="account_payment_mode.account_payment_method_form"
+        />
+        <field name="arch" type="xml">
+            <field name="bank_account_required" position="after">
+                <field
+                    name="fr_lcr_use_crlf"
+                    attrs="{'invisible': [('code','!=','fr_lcr')]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Small improvement of current module:

- Adds a boolean field on payment method that allows to disable/enable addition of CRLF within generated CFONB files. By default, it is set to 'True' so, there isn't any modification in the behavior of the module.

