### PR TITLE
[16.0][FIX] Don't re-define field company_registry

### DIFF
--- a/l10n_fr_siret/demo/partner_demo.xml
+++ b/l10n_fr_siret/demo/partner_demo.xml
@@ -9,7 +9,6 @@
     <record id="base.res_partner_12" model="res.partner">  <!-- C2C -->
         <field name="siren">433698578</field>
         <field name="nic">00039</field>
-        <field name="company_registry">Chambery</field>
     </record>
 
 </odoo>

--- a/l10n_fr_siret/models/res_company.py
+++ b/l10n_fr_siret/models/res_company.py
@@ -18,10 +18,3 @@ class ResCompany(models.Model):
     nic = fields.Char(
         string="NIC", related="partner_id.nic", store=True, readonly=False
     )
-    # company_registry field is definied in base module on res.company
-    company_registry = fields.Char(
-        string="Company Registry",
-        related="partner_id.company_registry",
-        store=True,
-        readonly=False,
-    )

--- a/l10n_fr_siret/models/res_partner.py
+++ b/l10n_fr_siret/models/res_partner.py
@@ -126,10 +126,6 @@ class Partner(models.Model):
         "of the SIREN number and the 5 digits of the NIC number, ie. "
         "14 digits.",
     )
-    company_registry = fields.Char(
-        help="The name of official registry where this company was declared.",
-    )
-
     parent_is_company = fields.Boolean(
         related="parent_id.is_company", string="Parent is a Company"
     )

--- a/l10n_fr_siret/views/res_partner.xml
+++ b/l10n_fr_siret/views/res_partner.xml
@@ -24,11 +24,6 @@
                 />
                 <field name="parent_is_company" invisible="1" />
             </field>
-            <field name="company_registry" position="attributes">
-                <attribute name="attrs" operation="update">
-                    {'readonly': [('parent_id', '!=', False)], 'invisible': [('is_company', '=', False), ('parent_is_company', '=', False)]}
-                </attribute>
-            </field>
             <field name="child_ids" position="attributes">
                 <attribute name="context" operation="update">
                     {'default_nic': nic}


### PR DESCRIPTION
Fix bug #501: don't redefine field company_registry on res.partner ; that field is defined in the "base" module since odoo v16