### PR TITLE
[IMP] l10n_fr_siret: warning for identical SIRET

### DIFF
--- a/l10n_fr_siret/README.rst
+++ b/l10n_fr_siret/README.rst
@@ -39,8 +39,10 @@ partners, but it doesn't verify its validity. This module
 -  multi-site companies have a single SIREN and one SIRET per site i.e.
    one NIC per site. This module allows to enter a specific NIC on child
    partners.
--  it adds a warning banner on the partner form view if another partner
-   has the same SIREN.
+-  it adds a warning banner on the partner form view either
+
+   -  if another partner has the same SIRET,
+   -  or if another partner has the same SIREN but different SIRET.
 
 |image1|
 
@@ -91,6 +93,8 @@ Contributors
 
 -  Lionel Sausin (Numérigraphe) <ls@numerigraphe.com>
 -  Alexis de Lattre <alexis.delattre@akretion.com>
+-  Vincent Van Rossem <vincent.vanrossem@camptocamp.com>
+-  
 
 Maintainers
 -----------

--- a/l10n_fr_siret/__manifest__.py
+++ b/l10n_fr_siret/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "French company identity numbers SIRET/SIREN/NIC",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.1.0",
     "category": "French Localization",
     "author": "Numérigraphe,Akretion,Odoo Community Association (OCA)",
     "maintainers": ["alexis-via"],

--- a/l10n_fr_siret/readme/CONTRIBUTORS.md
+++ b/l10n_fr_siret/readme/CONTRIBUTORS.md
@@ -1,2 +1,4 @@
 - Lionel Sausin (Numérigraphe) \<<ls@numerigraphe.com>\>
 - Alexis de Lattre \<<alexis.delattre@akretion.com>\>
+- Vincent Van Rossem \<<vincent.vanrossem@camptocamp.com>\>
+-

--- a/l10n_fr_siret/readme/DESCRIPTION.md
+++ b/l10n_fr_siret/readme/DESCRIPTION.md
@@ -9,7 +9,8 @@ partners, but it doesn't verify its validity. This module
 - multi-site companies have a single SIREN and one SIRET per site i.e.
   one NIC per site. This module allows to enter a specific NIC on child
   partners.
-- it adds a warning banner on the partner form view if another partner
-  has the same SIREN.
+- it adds a warning banner on the partner form view either
+  - if another partner has the same SIRET,
+  - or if another partner has the same SIREN but different SIRET.
 
 ![](static/description/partner_duplicate_warning.png)

--- a/l10n_fr_siret/static/description/index.html
+++ b/l10n_fr_siret/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -380,8 +381,11 @@ from SIRET.</li>
 <li>multi-site companies have a single SIREN and one SIRET per site i.e.
 one NIC per site. This module allows to enter a specific NIC on child
 partners.</li>
-<li>it adds a warning banner on the partner form view if another partner
-has the same SIREN.</li>
+<li>it adds a warning banner on the partner form view either<ul>
+<li>if another partner has the same SIRET,</li>
+<li>or if another partner has the same SIREN but different SIRET.</li>
+</ul>
+</li>
 </ul>
 <p><img alt="image1" src="https://raw.githubusercontent.com/OCA/l10n-france/17.0/l10n_fr_siret/static/description/partner_duplicate_warning.png" /></p>
 <p><strong>Table of contents</strong></p>
@@ -432,12 +436,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>Lionel Sausin (Numérigraphe) &lt;<a class="reference external" href="mailto:ls&#64;numerigraphe.com">ls&#64;numerigraphe.com</a>&gt;</li>
 <li>Alexis de Lattre &lt;<a class="reference external" href="mailto:alexis.delattre&#64;akretion.com">alexis.delattre&#64;akretion.com</a>&gt;</li>
+<li>Vincent Van Rossem &lt;<a class="reference external" href="mailto:vincent.vanrossem&#64;camptocamp.com">vincent.vanrossem&#64;camptocamp.com</a>&gt;</li>
+<li></li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/l10n_fr_siret/tests/test_fr_siret.py
+++ b/l10n_fr_siret/tests/test_fr_siret.py
@@ -53,7 +53,9 @@ class TestL10nFrSiret(TransactionCase):
         self.assertEqual(partner2.siren, "555555556")
         self.assertEqual(partner2.nic, "00011")
         self.assertEqual(partner2.same_siren_partner_id, partner1)
+        self.assertEqual(partner2.same_siret_partner_id, partner1)
         self.assertEqual(partner1.same_siren_partner_id, partner2)
+        self.assertEqual(partner1.same_siret_partner_id, partner2)
         partner3 = self.env["res.partner"].create(
             {
                 "name": "Test SIREN only",
@@ -105,9 +107,15 @@ class TestL10nFrSiret(TransactionCase):
             }
         )
         self.assertFalse(partner_company1.same_siren_partner_id)
+        self.assertFalse(partner_company1.same_siret_partner_id)
         self.assertFalse(partner_company2.same_siren_partner_id)
+        self.assertFalse(partner_company2.same_siret_partner_id)
         partner_company2.write({"company_id": False})
         self.assertEqual(partner_company2.same_siren_partner_id, partner_company1)
+        self.assertFalse(partner_company2.same_siret_partner_id, partner_company1)
+        partner_company2.write({"nic": False})
+        self.assertEqual(partner_company2.same_siren_partner_id, partner_company1)
+        self.assertEqual(partner_company2.same_siret_partner_id, partner_company1)
 
     def test_change_parent_id(self):
         partner = self.env["res.partner"].create(

--- a/l10n_fr_siret/views/res_partner.xml
+++ b/l10n_fr_siret/views/res_partner.xml
@@ -49,8 +49,18 @@
                 <div
                     class="alert alert-warning"
                     role="alert"
+                    name="warn_duplicate_siret"
+                    invisible="not same_siret_partner_id"
+                >
+                        Duplicate warning: partner <field
+                        name="same_siret_partner_id"
+                    /> has the same <b>SIRET</b>.
+                </div>
+                <div
+                    class="alert alert-warning"
+                    role="alert"
                     name="warn_duplicate_siren"
-                    invisible="not same_siren_partner_id"
+                    invisible="same_siret_partner_id or not same_siren_partner_id"
                 >
                         Duplicate warning: partner <field
                         name="same_siren_partner_id"


### PR DESCRIPTION
adds a warning banner on the partner form view either
- if another partner has the same SIRET,
- or if another partner has the same SIREN but different SIRET.