### PR TITLE
[16.0][FIX] l10n_fr_account_vat_return: filter on VAT taxes for France

### DIFF
--- a/l10n_fr_account_vat_return/models/l10n_fr_account_vat_return.py
+++ b/l10n_fr_account_vat_return/models/l10n_fr_account_vat_return.py
@@ -314,6 +314,7 @@ class L10nFrAccountVatReturn(models.Model):
             ("amount_type", "=", "percent"),
             ("amount", ">", 0),
             ("unece_type_code", "=", "VAT"),
+            ("country_id", "=", self.env.ref("base.fr").id),
         ]
         sale_regular_vat_tax_domain = vat_tax_domain + [
             ("fr_vat_autoliquidation", "=", False),


### PR DESCRIPTION
This commit adapts the code to the scenario where you have VAT taxes for other countries (EU B2C over 10k€, Polynésie française, ...)