### PR TITLE
[14.0][FIX] l10n_fr_account_vat_return: filter on VAT taxes for France

### DIFF
--- a/l10n_fr_account_vat_return/__manifest__.py
+++ b/l10n_fr_account_vat_return/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "France VAT Return",
-    "version": "14.0.9.0.0",
+    "version": "14.0.9.1.0",
     "category": "Accounting",
     "license": "AGPL-3",
     "summary": "VAT return for France: CA3, 3310-A, 3519",

--- a/l10n_fr_account_vat_return/migrations/14.0.9.1.0/post-migrate.py
+++ b/l10n_fr_account_vat_return/migrations/14.0.9.1.0/post-migrate.py
@@ -1,0 +1,18 @@
+# Copyright 2024 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        "UPDATE account_tax SET country_id=res_partner.country_id "
+        "FROM res_partner, res_company "
+        "WHERE account_tax.company_id=res_company.id AND "
+        "res_company.partner_id=res_partner.id AND "
+        "res_partner.country_id IS NOT NULL AND "
+        "account_tax.country_id IS NULL",
+    )

--- a/l10n_fr_account_vat_return/models/account_tax.py
+++ b/l10n_fr_account_vat_return/models/account_tax.py
@@ -12,6 +12,15 @@ class AccountTax(models.Model):
     fr_vat_autoliquidation = fields.Boolean(
         compute="_compute_fr_vat_autoliquidation", store=True, string="Autoliquidation"
     )
+    # The country_id field on account.tax is added in Odoo v15
+    # We just "backport" this field here, to be able to support scenarios
+    # where you have VAT taxes for other countries
+    country_id = fields.Many2one(
+        "res.country",
+        string="Country",
+        required=True,
+        help="The country for which this tax is applicable.",
+    )
 
     @api.depends(
         "type_tax_use",

--- a/l10n_fr_account_vat_return/models/l10n_fr_account_vat_return.py
+++ b/l10n_fr_account_vat_return/models/l10n_fr_account_vat_return.py
@@ -313,6 +313,7 @@ class L10nFrAccountVatReturn(models.Model):
             ("amount_type", "=", "percent"),
             ("amount", ">", 0),
             ("unece_type_code", "=", "VAT"),
+            ("country_id", "=", self.env.ref("base.fr").id),
         ]
         sale_regular_vat_tax_domain = vat_tax_domain + [
             ("fr_vat_autoliquidation", "=", False),

--- a/l10n_fr_account_vat_return/static/description/index.html
+++ b/l10n_fr_account_vat_return/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -420,9 +419,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/l10n_fr_account_vat_return/views/account_tax.xml
+++ b/l10n_fr_account_vat_return/views/account_tax.xml
@@ -11,7 +11,10 @@
     <field name="inherit_id" ref="account.view_tax_form" />
     <field name="arch" type="xml">
             <xpath expr="//field[@name='tax_scope']/.." position="inside">
-                        <field name="fr_vat_autoliquidation" />
+                <field name="fr_vat_autoliquidation" />
+        </xpath>
+            <xpath expr="//field[@name='description']/.." position="inside">
+                <field name="country_id" />
         </xpath>
     </field>
 </record>
@@ -21,6 +24,7 @@
         <field name="inherit_id" ref="account.view_tax_tree" />
         <field name="arch" type="xml">
                 <field name="company_id" position="before">
+                        <field name="country_id" optional="hide" />
                         <field name="fr_vat_autoliquidation" optional="hide" />
                 </field>
             </field>


### PR DESCRIPTION
This commit adapts the code to the scenario where you have VAT taxes for other countries (EU B2C over 10k€, Polynésie française, ...). It "backports" the field country_id on account.tax which is introduced in the account module in odoo v15.