### PR TITLE
[FWPORT][18.0][IMP] l10n_fr_siret: improve data migration script

### DIFF
--- a/l10n_fr_siret/post_install.py
+++ b/l10n_fr_siret/post_install.py
@@ -5,25 +5,42 @@
 
 import logging
 
-from stdnum.fr.siret import is_valid
+from stdnum.fr.siren import is_valid as siren_is_valid
+from stdnum.fr.siret import is_valid as siret_is_valid
 
 logger = logging.getLogger(__name__)
 
 
 def set_siren_nic(env):
+    logger.info("Starting data migration of fields siret/siren/nic on res.partner")
     partners = (
         env["res.partner"]
         .with_context(active_test=False)
         .search([("siret", "!=", False), ("parent_id", "=", False)])
     )
     for partner in partners:
-        if is_valid(partner.siret):
-            logger.info("Setting SIREN and NIC on partner %s", partner.display_name)
-            partner.write({"siret": partner.siret})
+        ini_siret = partner.siret.replace(" ", "")
+        if len(ini_siret) == 14 and siret_is_valid(ini_siret):
+            logger.debug("Setting SIREN and NIC on partner %s", partner.display_name)
+            partner.write({"siret": ini_siret})
+        elif len(ini_siret) == 9 and siren_is_valid(ini_siret):
+            logger.debug("Setting SIREN on partner %s", partner.display_name)
+            partner.write({"siren": ini_siret})
+        elif len(ini_siret) > 9 and siren_is_valid(ini_siret[:9]):
+            logger.info(
+                "Setting SIREN %s on partner %s. Wrong additional chars ignored "
+                "(bad initial SIRET was %s)",
+                ini_siret[:9],
+                partner.display_name,
+                ini_siret,
+            )
+            partner.write({"siren": ini_siret[:9]})
         else:
             logger.warning(
-                "Remove SIRET %s on partner %s because checksum is wrong",
-                partner.siret,
+                "Remove SIRET %s on partner %s (bad length and/or checksum, "
+                "doesn't start with valid SIREN)",
+                ini_siret,
                 partner.display_name,
             )
             partner.write({"siret": False})
+    logger.info("End of data migration of fields siret/siren/nic on res.partner")


### PR DESCRIPTION
Improve data migration for fields siret/siren/nic: if we have a valid siren inside a bad siret, we keep the siren.

This is a fwport of
https://github.com/OCA/l10n-france/pull/630