### PR TITLE
[18.0][IMP] l10n_fr_siret: M2M for duplicate partners

### DIFF
--- a/l10n_fr_siret/models/res_partner.py
+++ b/l10n_fr_siret/models/res_partner.py
@@ -47,10 +47,10 @@ class Partner(models.Model):
     parent_is_company = fields.Boolean(
         related="parent_id.is_company", string="Parent is a Company"
     )
-    same_siren_partner_id = fields.Many2one(
+    same_siren_partner_ids = fields.Many2many(
         "res.partner",
-        compute="_compute_same_siren_partner_id",
-        string="Partner with same SIREN",
+        compute="_compute_same_siren_partner_ids",
+        string="Partners with same SIREN",
         compute_sudo=True,
     )
 
@@ -79,10 +79,10 @@ class Partner(models.Model):
                 rec.write({"siren": False, "nic": False})
 
     @api.depends("siren", "company_id")
-    def _compute_same_siren_partner_id(self):
+    def _compute_same_siren_partner_ids(self):
         # Inspired by same_vat_partner_id from 'base' module
         for partner in self:
-            same_siren_partner_id = False
+            same_siren_partner_ids = False
             if partner.siren and not partner.parent_id:
                 domain = [
                     ("siren", "=", partner.siren),
@@ -98,10 +98,10 @@ class Partner(models.Model):
                 partner_id = partner._origin.id
                 if partner_id:
                     domain.append(("id", "!=", partner_id))
-                same_siren_partner_id = (
-                    self.with_context(active_test=False).search(domain, limit=1)
-                ).id or False
-            partner.same_siren_partner_id = same_siren_partner_id
+                same_siren_partner_ids = (
+                    self.with_context(active_test=False).search(domain)
+                ).ids or False
+            partner.same_siren_partner_ids = same_siren_partner_ids
 
     @api.constrains("siren", "nic")
     def _check_siret(self):
@@ -158,3 +158,21 @@ class Partner(models.Model):
         res = super()._address_fields()
         res.append("nic")
         return res
+
+    def action_open_business_doc(self):
+        """Method called when you click on the link in the duplicate warning banner"""
+        # WARNING: the exact same method is provided by the modules
+        # partner_mobile_duplicate_warn and partner_email_duplicate_warn.
+        # Let's hope that in future versions of Odoo this method will be present
+        # in the "base" module and we'll remove that code!
+        self.ensure_one()
+        action = {
+            "name": _("Partners"),
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "views": [(False, "form")],
+            "res_model": self._name,
+            "res_id": self.id,
+            "target": "current",
+        }
+        return action

--- a/l10n_fr_siret/tests/test_fr_siret.py
+++ b/l10n_fr_siret/tests/test_fr_siret.py
@@ -39,7 +39,7 @@ class TestL10nFrSiret(TransactionCase):
             }
         )
         self.assertEqual(partner1.siret, "55555555600011")
-        self.assertFalse(partner1.same_siren_partner_id)
+        self.assertFalse(partner1.same_siren_partner_ids)
         # Try to update SIRET
         partner1.write({"siret": "81862078300048"})
         partner1.write({"siren": "792377731", "nic": "00023"})
@@ -52,8 +52,8 @@ class TestL10nFrSiret(TransactionCase):
         )
         self.assertEqual(partner2.siren, "555555556")
         self.assertEqual(partner2.nic, "00011")
-        self.assertEqual(partner2.same_siren_partner_id, partner1)
-        self.assertEqual(partner1.same_siren_partner_id, partner2)
+        self.assertEqual(partner2.same_siren_partner_ids, partner1)
+        self.assertEqual(partner1.same_siren_partner_ids, partner2)
         partner3 = self.env["res.partner"].create(
             {
                 "name": "Test SIREN only",
@@ -61,6 +61,8 @@ class TestL10nFrSiret(TransactionCase):
             }
         )
         self.assertEqual(partner3.siret, "555555556*****")
+        self.assertIn(partner1, partner3.same_siren_partner_ids)
+        self.assertIn(partner2, partner3.same_siren_partner_ids)
         partner4 = self.env["res.partner"].create(
             {
                 "name": "Test SIREN only",
@@ -70,6 +72,9 @@ class TestL10nFrSiret(TransactionCase):
         self.assertEqual(partner4.siren, "555555556")
         self.assertFalse(partner4.nic)
         self.assertEqual(partner4.siret, "555555556*****")
+        self.assertIn(partner1, partner4.same_siren_partner_ids)
+        self.assertIn(partner2, partner4.same_siren_partner_ids)
+        self.assertIn(partner3, partner4.same_siren_partner_ids)
 
     def test_wrong_siret(self):
         vals = {"name": "Wrong Akretion France"}
@@ -104,10 +109,10 @@ class TestL10nFrSiret(TransactionCase):
                 "company_id": self.company2_id,
             }
         )
-        self.assertFalse(partner_company1.same_siren_partner_id)
-        self.assertFalse(partner_company2.same_siren_partner_id)
+        self.assertFalse(partner_company1.same_siren_partner_ids)
+        self.assertFalse(partner_company2.same_siren_partner_ids)
         partner_company2.write({"company_id": False})
-        self.assertEqual(partner_company2.same_siren_partner_id, partner_company1)
+        self.assertEqual(partner_company2.same_siren_partner_ids, partner_company1)
 
     def test_change_parent_id(self):
         partner = self.env["res.partner"].create(

--- a/l10n_fr_siret/views/res_partner.xml
+++ b/l10n_fr_siret/views/res_partner.xml
@@ -45,11 +45,12 @@
                     class="alert alert-warning"
                     role="alert"
                     name="warn_duplicate_siren"
-                    invisible="not same_siren_partner_id"
+                    invisible="not same_siren_partner_ids"
                 >
-                        Duplicate warning: partner <field
-                    name="same_siren_partner_id"
-                /> has the same <b>SIREN</b>.
+                        Duplicate warning: partner(s) <field
+                    name="same_siren_partner_ids"
+                    widget="x2many_buttons"
+                /> has/have the same <b>SIREN</b>.
                 </div>
             </div>
         </field>


### PR DESCRIPTION
The warning banner for duplicate siren partners is now a many2many instead of a many2one, taking advantage of the new widget introduced in v18.

![Uploading dupli.png…]()
