### PR TITLE
[18.0][FIX] l10n_fr_department La Réunion

### DIFF
--- a/l10n_fr_department/model/res_partner.py
+++ b/l10n_fr_department/model/res_partner.py
@@ -97,8 +97,12 @@ class ResPartner(models.Model):
         }
         if zipcode in special_zipcodes:
             return special_zipcodes[zipcode]
+        # La Réunion
         if code == "97":
             code = zipcode[0:3]
+            # Le Port
+            if code == "978":
+                code = "974"
         elif code == "20":
             try:
                 zipcode = int(zipcode)


### PR DESCRIPTION
Les codes postaux CEDEX en 978 de Le Port à La Réunion n'étaient pas gérés dans le calcul automatique du `country_department_id`.