### PR TITLE
[17.0] Chorus: source for chorus service can be easily inherited + fix when a flow has more than 10 invoices

### DIFF
--- a/l10n_fr_chorus_account/models/account_move.py
+++ b/l10n_fr_chorus_account/models/account_move.py
@@ -80,6 +80,11 @@ class AccountMove(models.Model):
         string="Chorus Attachments",
         copy=False,
     )
+    chorus_service_code = fields.Char(
+        related="partner_id.fr_chorus_service_id.code",
+        string="Chorus Service Code",
+        store=True,
+    )
 
     @api.constrains("chorus_attachment_ids", "transmit_method_id")
     def _check_chorus_attachments(self):

--- a/l10n_fr_chorus_account/models/account_move.py
+++ b/l10n_fr_chorus_account/models/account_move.py
@@ -177,7 +177,7 @@ class AccountMove(models.Model):
     def _chorus_validation_checks(self):
         self.ensure_one()
         self.company_id._chorus_common_validation_checks(
-            self, self.partner_id, self.ref
+            self, self.partner_id, self.ref, self._get_chorus_service()
         )
         if self.move_type == "out_invoice":
             if not self.payment_mode_id:
@@ -239,6 +239,10 @@ class AccountMove(models.Model):
     def chorus_get_invoice(self, chorus_invoice_format):
         self.ensure_one()
         return False
+
+    def _get_chorus_service(self):
+        self.ensure_one()
+        return self.partner_id.fr_chorus_service_id
 
     def _prepare_chorus_deposer_flux_payload(self):
         if not self[0].company_id.fr_chorus_invoice_format:

--- a/l10n_fr_chorus_account/models/chorus_flow.py
+++ b/l10n_fr_chorus_account/models/chorus_flow.py
@@ -186,6 +186,9 @@ class ChorusFlow(models.Model):
         url_path = "factures/v1/rechercher/fournisseur"
         payload = {
             "numeroFluxDepot": self.name,
+            "rechercheFactureParFournisseur": {
+                "nbResultatsParPage": len(self.initial_invoice_ids) + 2,
+            },
         }
         answer, session = self.env["res.company"]._chorus_post(
             api_params, url_path, payload

--- a/l10n_fr_chorus_account/models/chorus_partner_service.py
+++ b/l10n_fr_chorus_account/models/chorus_partner_service.py
@@ -24,7 +24,7 @@ class ChorusPartnerService(models.Model):
     )
     code = fields.Char(string="Service Code", required=True)
     active = fields.Boolean(default=True)
-    name = fields.Char(string="Service Name")
+    name = fields.Char(string="Service Name", required=True)
     chorus_identifier = fields.Integer(readonly=True)
     engagement_required = fields.Boolean()
 
@@ -85,6 +85,15 @@ class ChorusPartnerService(models.Model):
         return super()._name_search(
             name, domain=domain, operator=operator, limit=limit, order=order
         )
+
+    def _is_service_ok(self):
+        if not self:
+            return False
+        if not self.active:
+            return False
+        if not self.name:
+            return False
+        return True
 
     def _api_consulter_service(self, api_params, session):
         assert self.chorus_identifier

--- a/l10n_fr_chorus_account/models/res_company.py
+++ b/l10n_fr_chorus_account/models/res_company.py
@@ -363,7 +363,7 @@ class ResCompany(models.Model):
         self.ensure_one()
 
     def _chorus_common_validation_checks(
-        self, source_object, invoice_partner, client_order_ref
+        self, source_object, invoice_partner, client_order_ref, chorus_service
     ):
         self.ensure_one()
         assert invoice_partner
@@ -374,6 +374,7 @@ class ResCompany(models.Model):
         else:
             partner_field = _("Customer")
         company_partner = self.partner_id
+        chorus_service_ok = chorus_service and chorus_service._is_service_ok()
         if not company_partner.siren or not company_partner.nic:
             raise UserError(
                 _(
@@ -396,7 +397,7 @@ class ResCompany(models.Model):
             )
         if (
             cpartner.fr_chorus_required in ("service", "service_and_engagement")
-            and not invoice_partner._chorus_service_ok()
+            and not chorus_service_ok
         ):
             raise UserError(
                 _(
@@ -428,10 +429,7 @@ class ResCompany(models.Model):
                     }
                 )
             self._chorus_check_commitment_number(source_object, client_order_ref)
-        elif (
-            invoice_partner.fr_chorus_service_id
-            and invoice_partner.fr_chorus_service_id.engagement_required
-        ):
+        elif chorus_service and chorus_service.engagement_required:
             if not client_order_ref:
                 raise UserError(
                     _(
@@ -449,7 +447,7 @@ class ResCompany(models.Model):
                 )
             self._chorus_check_commitment_number(source_object, client_order_ref)
         if cpartner.fr_chorus_required == "service_or_engagement":
-            if not invoice_partner._chorus_service_ok():
+            if not chorus_service_ok:
                 if not client_order_ref:
                     raise UserError(
                         _(

--- a/l10n_fr_chorus_account/models/res_company.py
+++ b/l10n_fr_chorus_account/models/res_company.py
@@ -309,6 +309,15 @@ class ResCompany(models.Model):
 
         answer = r.json()
         logger.info("Chorus WS answer payload: %s", answer)
+        if (
+            answer.get("parametresRetour")
+            and answer["parametresRetour"].get("pages")
+            and answer["parametresRetour"]["pages"] > 1
+        ):
+            logger.warning(
+                "The Chorus answer payload has several pages. Make sure the code loops "
+                "on the multiple pages or increase the nbResultatsParPage in the query."
+            )
         return (answer, session)
 
     def chorus_expiry_remind_user_list(self):

--- a/l10n_fr_chorus_account/models/res_partner.py
+++ b/l10n_fr_chorus_account/models/res_partner.py
@@ -444,16 +444,3 @@ class ResPartner(models.Model):
             chorus_raise_if_ko=False
         ).fr_chorus_identifier_and_required_button()
         logger.info("End Chorus partner cron")
-
-    def _chorus_service_ok(self):
-        # Method used upon SO or invoice validation
-        self.ensure_one()
-        if (
-            self.parent_id
-            and self.name
-            and self.fr_chorus_service_id
-            and self.fr_chorus_service_id.active
-        ):
-            return True
-        else:
-            return False

--- a/l10n_fr_chorus_account/security/group.xml
+++ b/l10n_fr_chorus_account/security/group.xml
@@ -9,6 +9,10 @@
             <field name="name">Chorus API</field>
             <field name="category_id" ref="base.module_category_hidden" />
         </record>
+        <record id="group_chorus_api_debug" model="res.groups">
+            <field name="name">Chorus API Debugging</field>
+            <field name="category_id" ref="base.module_category_hidden" />
+        </record>
     </data>
     <data noupdate="1">
         <record id="chorus_flow_rule" model="ir.rule">

--- a/l10n_fr_chorus_account/security/ir.model.access.csv
+++ b/l10n_fr_chorus_account/security/ir.model.access.csv
@@ -1,4 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_chorus_flow_readonly,Read-only access on chorus.flow to account viewer,model_chorus_flow,account.group_account_readonly,1,0,0,0
 access_chorus_flow_user,Read/Write/Create access on chorus.flow to invoicing grp,model_chorus_flow,account.group_account_invoice,1,1,1,0
 access_chorus_flow_full,Full access on chorus.flow to system grp,model_chorus_flow,base.group_system,1,1,1,1
 access_chorus_partner_service_full,Full access on chorus.partner.service to system grp,model_chorus_partner_service,base.group_system,1,1,1,1

--- a/l10n_fr_chorus_account/views/account_move.xml
+++ b/l10n_fr_chorus_account/views/account_move.xml
@@ -10,6 +10,12 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account_invoice_transmit_method.view_move_form" />
         <field name="arch" type="xml">
+            <field name="partner_shipping_id" position="before">
+                <field
+                    name="chorus_service_code"
+                    invisible="transmit_method_code != 'fr-chorus'"
+                />
+            </field>
             <button name="action_invoice_sent" position="after">
                 <button
                     name="%(account_invoice_chorus_send_action)d"
@@ -78,8 +84,19 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_invoice_tree" />
         <field name="arch" type="xml">
+            <field name="invoice_date" position="before">
+                <field
+                    name="chorus_service_code"
+                    optional="hide"
+                    column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund')"
+                />
+            </field>
             <field name="payment_state" position="after">
-                <field name="chorus_status" optional="hide" />
+                <field
+                    name="chorus_status"
+                    optional="hide"
+                    column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund')"
+                />
             </field>
         </field>
     </record>

--- a/l10n_fr_chorus_account/views/account_move.xml
+++ b/l10n_fr_chorus_account/views/account_move.xml
@@ -20,6 +20,16 @@
                     groups="l10n_fr_chorus_account.group_chorus_api"
                 />
             </button>
+            <!-- disallow modification of transmit method on posted invoiced, because it allows
+            users to switch to Chorus after confirmation, which by-passes
+            the Chorus-specific checks -->
+            <field
+                name="transmit_method_id"
+                invisible="move_type not in ('out_invoice', 'out_refund')"
+                position="attributes"
+            >
+                    <attribute name="readonly">state != 'draft'</attribute>
+            </field>
             <notebook position="inside">
                 <page
                     name="fr-chorus"

--- a/l10n_fr_chorus_account/views/account_move.xml
+++ b/l10n_fr_chorus_account/views/account_move.xml
@@ -30,17 +30,25 @@
                 <group name="chorus-tab">
                     <group name="chorus-main">
                         <field name="chorus_flow_id" />
-                        <field name="chorus_identifier" />
-                        <field name="chorus_status" />
-                        <field name="chorus_status_date" />
-                        <button
-                                name="chorus_update_invoice_status"
-                                type="object"
-                                string="Update Chorus Invoice Status"
-                                invisible="chorus_identifier in (False, 0)"
-                                colspan="2"
-                                class="btn-default"
+                        <field name="chorus_identifier" invisible="1" />
+                        <field
+                                name="chorus_identifier"
+                                groups="l10n_fr_chorus_account.group_chorus_api_debug"
                             />
+                        <label for="chorus_status" />
+                        <div name="chorus_status" class="o_col">
+                            <field name="chorus_status" class="oe_inline" />
+                            <button
+                                    name="chorus_update_invoice_status"
+                                    type="object"
+                                    string="Update"
+                                    help="Update Chorus Invoice Status"
+                                    class="btn-link mb-1 px-0"
+                                    icon="fa-refresh"
+                                    invisible="not chorus_identifier"
+                                />
+                        </div>
+                        <field name="chorus_status_date" />
                     </group>
                 <group name="chorus-attachments" string="Attachments">
                         <field

--- a/l10n_fr_chorus_account/views/chorus_flow.xml
+++ b/l10n_fr_chorus_account/views/chorus_flow.xml
@@ -22,7 +22,8 @@
                         string="Get Chorus Invoice Identifiers"
                         invisible="status not in ('IN_INTEGRE', 'IN_INTEGRE_PARTIEL') or invoice_identifiers"
                     />
-                </header>
+            </header>
+            <sheet>
                 <group name="main">
                     <group name="main-left">
                         <field name="name" />
@@ -45,9 +46,9 @@
                 <group name="invoices" string="Invoices">
                     <field name="invoice_ids" nolabel="1" colspan="2">
                         <tree
-                            decoration-info="state == 'draft'"
-                            decoration-muted="state == 'cancel'"
-                        >
+                                decoration-info="state == 'draft'"
+                                decoration-muted="state == 'cancel'"
+                            >
                             <field name="partner_id" string="Customer" />
                             <field name="invoice_date" />
                             <field name="name" />
@@ -57,12 +58,16 @@
                             <field name="currency_id" invisible="1" />
                             <field name="state" invisible="1" />
                             <field name="payment_state" />
-                            <field name="chorus_identifier" />
+                            <field
+                                    name="chorus_identifier"
+                                    groups="l10n_fr_chorus_account.group_chorus_api_debug"
+                                />
                             <field name="chorus_status" />
                             <field name="chorus_status_date" />
                         </tree>
                     </field>
                 </group>
+        </sheet>
             </form>
         </field>
     </record>
@@ -98,6 +103,8 @@
         <field name="arch" type="xml">
             <search>
                 <field name="name" />
+                <separator />
+                <filter string="Date" name="date" date="date" />
                 <group string="Group By" name="groupby">
                     <filter
                         name="status_groupby"

--- a/l10n_fr_chorus_account/views/chorus_partner_service.xml
+++ b/l10n_fr_chorus_account/views/chorus_partner_service.xml
@@ -27,7 +27,7 @@
                     <field name="active" invisible="1" />
                     <field
                         name="chorus_identifier"
-                        groups="l10n_fr_chorus_account.group_chorus_api"
+                        groups="l10n_fr_chorus_account.group_chorus_api_debug"
                     />
                 </group>
             </form>
@@ -47,7 +47,7 @@
                 <field name="engagement_required" />
                 <field
                     name="chorus_identifier"
-                    groups="l10n_fr_chorus_account.group_chorus_api"
+                    groups="l10n_fr_chorus_account.group_chorus_api_debug"
                 />
             </tree>
         </field>

--- a/l10n_fr_chorus_account/views/res_partner.xml
+++ b/l10n_fr_chorus_account/views/res_partner.xml
@@ -41,15 +41,29 @@
                     <button
                         name="fr_chorus_identifier_and_required_button"
                         type="object"
-                        string="Update Chorus Info and Services"
+                        string="Get Chorus Info and Services"
                         colspan="2"
                         class="btn-primary"
                         groups="l10n_fr_chorus_account.group_chorus_api"
+                        invisible="fr_chorus_required"
                     />
-                    <field name="fr_chorus_required" />
+                    <label for="fr_chorus_required" />
+                    <div name="fr_chorus_required" class="o_row">
+                        <field name="fr_chorus_required" />
+                        <button
+                            name="fr_chorus_identifier_and_required_button"
+                            type="object"
+                            string="Update"
+                            class="btn-link mb-1 px-0"
+                            icon="fa-refresh"
+                            groups="l10n_fr_chorus_account.group_chorus_api"
+                            invisible="not fr_chorus_required"
+                            help="Update Info Required for Chorus and Chorus Services"
+                        />
+                    </div>
                     <field
                         name="fr_chorus_identifier"
-                        groups="l10n_fr_chorus_account.group_chorus_api"
+                        groups="l10n_fr_chorus_account.group_chorus_api_debug"
                     />
                     <button
                         type="action"

--- a/l10n_fr_chorus_account/views/res_partner.xml
+++ b/l10n_fr_chorus_account/views/res_partner.xml
@@ -10,14 +10,6 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <field name="ref" position="after">
-                <field
-                    name="fr_chorus_service_id"
-                    invisible="not parent_id or customer_invoice_transmit_method_code != 'fr-chorus'"
-                    domain="[('partner_id', '=', parent_id)]"
-                    context="{'default_partner_id': parent_id}"
-                />
-            </field>
             <xpath
                 expr="//field[@name='child_ids']/form//label[@for='street']"
                 position="before"
@@ -33,6 +25,26 @@
                 expr="//page[@name='sales_purchases']/group[@name='container_row_2']"
                 position="inside"
             >
+                <group
+                    name="fr-chorus-child"
+                    string="Chorus Pro"
+                    invisible="not parent_id or customer_invoice_transmit_method_code != 'fr-chorus'"
+                >
+                    <field
+                        name="fr_chorus_service_id"
+                        invisible="type != 'invoice'"
+                        domain="[('partner_id', '=', parent_id)]"
+                        context="{'default_partner_id': parent_id}"
+                    />
+                    <div name="parent_chorus" colspan="2">
+                        <p>Other Chorus parameters are managed on <button
+                                name="open_commercial_entity"
+                                type="object"
+                                string="the parent company"
+                                class="oe_link"
+                            /></p>
+                    </div>
+                </group>
                 <group
                     name="fr-chorus"
                     string="Chorus Pro"

--- a/l10n_fr_chorus_account/views/res_partner.xml
+++ b/l10n_fr_chorus_account/views/res_partner.xml
@@ -92,6 +92,17 @@
                     </button>
                 </group>
             </xpath>
+            <xpath expr="//field[@name='child_ids']/kanban" position="inside">
+                <field name="fr_chorus_service_id" />
+            </xpath>
+            <xpath
+                expr="//field[@name='child_ids']/kanban/templates/t[@t-name='kanban-box']//div[@t-if='record.mobile.raw_value']"
+                position="after"
+            >
+                <div t-if="record.fr_chorus_service_id.raw_value">Chorus Service: <field
+                        name="fr_chorus_service_id"
+                    /></div>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/l10n_fr_chorus_account/views/res_partner.xml
+++ b/l10n_fr_chorus_account/views/res_partner.xml
@@ -55,7 +55,7 @@
                         type="action"
                         class="btn-link"
                         name="%(chorus_partner_service_action)d"
-                        context="{'search_default_partner_id': active_id, 'default_partner_id': active_id}"
+                        context="{'search_default_partner_id': id, 'default_partner_id': id}"
                         colspan="2"
                     >
                         <field

--- a/l10n_fr_chorus_facturx/models/account_move.py
+++ b/l10n_fr_chorus_facturx/models/account_move.py
@@ -2,22 +2,23 @@
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models
+from odoo import models
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    @api.model
     def _cii_trade_contact_department_name(self, partner):
-        if partner.fr_chorus_service_id:
-            return partner.name
+        chorus_service = self._get_chorus_service()
+        if chorus_service:
+            dpt_name = chorus_service.name or partner.name
+            return dpt_name
         return super()._cii_trade_contact_department_name(partner)
 
-    @api.model
     def _cii_trade_agreement_buyer_ref(self, partner):
-        if partner.fr_chorus_service_id:
-            return partner.fr_chorus_service_id.code
+        chorus_service = self._get_chorus_service()
+        if chorus_service:
+            return chorus_service.code
         return super()._cii_trade_agreement_buyer_ref(partner)
 
     def chorus_get_invoice(self, chorus_invoice_format):

--- a/l10n_fr_chorus_sale/models/sale_order.py
+++ b/l10n_fr_chorus_sale/models/sale_order.py
@@ -15,6 +15,11 @@ class SaleOrder(models.Model):
     invoice_transmit_method_code = fields.Char(
         related="partner_invoice_id.customer_invoice_transmit_method_id.code",
     )
+    chorus_service_code = fields.Char(
+        related="partner_invoice_id.fr_chorus_service_id.code",
+        string="Chorus Service Code",
+        store=True,
+    )
 
     def action_confirm(self):
         """Check validity of Chorus orders"""

--- a/l10n_fr_chorus_sale/models/sale_order.py
+++ b/l10n_fr_chorus_sale/models/sale_order.py
@@ -24,8 +24,15 @@ class SaleOrder(models.Model):
             order._chorus_validation_checks()
         return super().action_confirm()
 
+    def _get_chorus_service(self):
+        self.ensure_one()
+        return self.partner_invoice_id.fr_chorus_service_id
+
     def _chorus_validation_checks(self):
         self.ensure_one()
         self.company_id._chorus_common_validation_checks(
-            self, self.partner_invoice_id, self.client_order_ref
+            self,
+            self.partner_invoice_id,
+            self.client_order_ref,
+            self._get_chorus_service(),
         )

--- a/l10n_fr_chorus_sale/views/sale_order.xml
+++ b/l10n_fr_chorus_sale/views/sale_order.xml
@@ -10,10 +10,36 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
+            <field name="partner_invoice_id" position="after">
+                <field
+                    name="chorus_service_code"
+                    invisible="invoice_transmit_method_code != 'fr-chorus'"
+                />
+            </field>
             <group name="sale_info" position="inside">
                 <field name="invoice_transmit_method_id" />
                 <field name="invoice_transmit_method_code" invisible="1" />
             </group>
+        </field>
+    </record>
+    <record id="view_order_tree" model="ir.ui.view">
+        <field name="name">chorus.sale.order.tree</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_tree" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="chorus_service_code" optional="hide" />
+            </field>
+        </field>
+    </record>
+    <record id="view_quotation_tree" model="ir.ui.view">
+        <field name="name">chorus.sale.order.quotation.tree</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_quotation_tree" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="chorus_service_code" optional="hide" />
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Don't hard-code chorus service source from invoice_partner.fr_chorus_service_id. Allows to have another source for
 chorus service by inheriting l10n_fr_chorus_account.