### PR TITLE
[15.0][FIX] l10n_fr_chorus_account: fix when a chorus flow has more than 10 invoices

### DIFF
--- a/l10n_fr_chorus_account/models/chorus_flow.py
+++ b/l10n_fr_chorus_account/models/chorus_flow.py
@@ -176,6 +176,9 @@ class ChorusFlow(models.Model):
         url_path = "factures/v1/rechercher/fournisseur"
         payload = {
             "numeroFluxDepot": self.name,
+            "rechercheFactureParFournisseur": {
+                "nbResultatsParPage": len(self.initial_invoice_ids) + 2,
+            },
         }
         answer, session = self.env["res.company"].chorus_post(
             api_params, url_path, payload

--- a/l10n_fr_chorus_account/models/res_company.py
+++ b/l10n_fr_chorus_account/models/res_company.py
@@ -299,6 +299,15 @@ class ResCompany(models.Model):
 
         answer = r.json()
         logger.info("Chorus WS answer payload: %s", answer)
+        if (
+            answer.get("parametresRetour")
+            and answer["parametresRetour"].get("pages")
+            and answer["parametresRetour"]["pages"] > 1
+        ):
+            logger.warning(
+                "The Chorus answer payload has several pages. Make sure the code loops "
+                "on the multiple pages or increase the nbResultatsParPage in the query."
+            )
         return (answer, session)
 
     def chorus_expiry_remind_user_list(self):


### PR DESCRIPTION
Fix when a chorus flow has more than 10 invoices: odoo now gets the invoice identifiers for all the invoices and not only 10. Add warning when the payload of an answer declares several pages.