### PR TITLE
[CI] tests with Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,14 +35,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest
+          - container: ghcr.io/oca/oca-ci/py3.8-odoo14.0:latest
             name: test with Odoo
-          - container: ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest
+          - container: ghcr.io/oca/oca-ci/py3.8-ocb14.0:latest
             name: test with OCB
             makepot: "true"
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:12.0
         env:
           POSTGRES_USER: odoo
           POSTGRES_PASSWORD: odoo


### PR DESCRIPTION
attempt to run the CI for 14.0 on Python 3.8

see https://github.com/OCA/l10n-france/pull/655