### PR TITLE
[16.0][FIX] l10n_fr_intrastat_product: Remove error blocking region code when warehouse has no partner

### DIFF
--- a/l10n_fr_intrastat_product/models/stock.py
+++ b/l10n_fr_intrastat_product/models/stock.py
@@ -2,8 +2,7 @@
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, models
-from odoo.exceptions import UserError
+from odoo import models
 
 
 class StockWarehouse(models.Model):
@@ -11,9 +10,7 @@ class StockWarehouse(models.Model):
 
     def _get_fr_department(self):
         self.ensure_one()
-        if not self.partner_id:
-            raise UserError(_("Missing partner on warehouse '%s'.") % self.display_name)
-        return self.partner_id.country_department_id
+        return self.partner_id.country_department_id if self.partner_id else None
 
 
 class StockLocation(models.Model):


### PR DESCRIPTION
@tecnativa TT55417
@victoralmau @alexis-via @pedrobaeza 

In cases where there's no partner_id for example, in a virtual warehouse it should fall back to the one you've established as the priority, which is the company's partner country_department_id. Is that correct, @alexis-via, according to the French localization requirements?

The UserError i removed was blocking this logic https://github.com/OCA/l10n-france/blob/210d2f45e1c3e6bb9087db3ec8d9bb95a0a599e2/l10n_fr_intrastat_product/models/intrastat_product_declaration.py#L97 and forcing the use of partner_id. 

And if the partner’s department cannot be found on the company either, it will then fall back to this logic https://github.com/OCA/l10n-france/blob/210d2f45e1c3e6bb9087db3ec8d9bb95a0a599e2/l10n_fr_intrastat_product/models/intrastat_product_declaration.py#L98 which was also broken.