### PR TITLE
[16.0][FIX] l10n_fr_pos_caisse_ap_ip: check payment terminal answer only on success

### DIFF
--- a/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py
+++ b/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py
@@ -234,10 +234,10 @@ class PosPaymentMethod(models.Model):
 
     def _fr_caisse_ap_ip_answer(self, answer, msg_dict):
         answer_dict = self._fr_caisse_ap_ip_parse_answer(answer)
-        check_res = self._fr_caisse_ap_ip_check_answer(answer_dict, msg_dict)
-        if isinstance(check_res, dict):
-            return check_res
         if answer_dict.get("AE") == "10":
+            check_res = self._fr_caisse_ap_ip_check_answer(answer_dict, msg_dict)
+            if isinstance(check_res, dict):
+                return check_res
             res = self._fr_caisse_ap_ip_prepare_success(answer_dict)
         elif answer_dict.get("AE") == "01":
             res = self._fr_caisse_ap_ip_prepare_failure(answer_dict)


### PR DESCRIPTION
Seen today on an Ingenico Desk/5000 : when you cancel a payment transaction by pushing the red button, the answer from the payment terminal will not contain the initial amount in the CB tag and the user will get this error:
```
Caisse AP IP protocol: Tag amount (CB) has value 350 in the request and  in the answer, but these values should be identical. This should never happen!
```

We now check the answer only upon success.