### PR TITLE
[12.0][FIX] account_banking_fr_lcr: do not search on non stored acc_type field

### DIFF
--- a/account_banking_fr_lcr/models/account_move_line.py
+++ b/account_banking_fr_lcr/models/account_move_line.py
@@ -16,8 +16,7 @@ class AccountMoveLine(models.Model):
             # Take the first IBAN account of the partner
             bank_account = self.env['res.partner.bank'].search([
                 ('partner_id', '=', self.partner_id.id),
-                ('acc_type', '=', 'iban'),
-                ], limit=1)
+                ]).filtered(lambda acc: acc.acc_type == "iban")
             if bank_account:
-                vals['partner_bank_id'] = bank_account.id
+                vals['partner_bank_id'] = bank_account[:1].id
         return vals


### PR DESCRIPTION
When trying to generate payment_lines, you get the following error :
`Non-stored field res.partner.bank.acc_type cannot be searched.`