### PR TITLE
[16][FIX] l10n_fr_fec: more robust/exhautive way to get rid of invisible caracters (like line break)

### DIFF
--- a/l10n_fr_fec_oca/wizard/account_fr_fec_oca.py
+++ b/l10n_fr_fec_oca/wizard/account_fr_fec_oca.py
@@ -538,7 +538,7 @@ class AccountFrFecOca(models.TransientModel):
             TO_CHAR(COALESCE(am.invoice_date, am.date), 'YYYYMMDD') AS PieceDate,
             CASE WHEN aml.name IS NULL OR aml.name = '' THEN '/'
                 WHEN aml.name SIMILAR TO '[\\t|\\s|\\n]*' THEN '/'
-                ELSE REGEXP_REPLACE(replace(aml.name, '|', '/'), '[\\t\\n\\r]', ' ', 'g')
+                ELSE REGEXP_REPLACE(replace(aml.name, '|', '/'), '[[:cntrl:]]', ' ', 'g')
             END AS EcritureLib,
             replace(
                 CASE WHEN aml.debit = 0


### PR DESCRIPTION
Recently I had a problem with invalid FEC (not read correctly by excel not valid with a fec validation tools, because of the presence of vertical tab (\x0B)
This PR aims to get rid of this kind of characters in a more exhaustive manner

