### PR TITLE
[18.0][IMP] l10n_fr_intrastat_product: Remove menu entry

### DIFF
--- a/account_payment_fr_lcr/models/account_move.py
+++ b/account_payment_fr_lcr/models/account_move.py
@@ -266,12 +266,9 @@ class AccountMove(models.Model):
         with tools.file_open(
             "account_payment_fr_lcr/reports/lettre_de_change.pdf", "rb"
         ) as empty_report_fd:
-            empty_report_reader = PdfReader(empty_report_fd)
-            final_report_writer = PdfWriter()
+            final_report_writer = PdfWriter(empty_report_fd)
             # add the "watermark" (which is the new pdf) on the existing page
-            page = empty_report_reader.pages[0]
-            page.merge_page(watermark_pdf_reader.pages[0])
-            final_report_writer.add_page(page)
+            final_report_writer.pages[0].merge_page(watermark_pdf_reader.pages[0])
             final_report_writer.pages[0].compress_content_streams()
             # finally, write "output" to a real file
             final_report_io = io.BytesIO()

--- a/l10n_fr_intrastat_product/views/intrastat_product_declaration.xml
+++ b/l10n_fr_intrastat_product/views/intrastat_product_declaration.xml
@@ -84,19 +84,4 @@
             </field>
         </field>
     </record>
-
-    <record
-        id="l10n_fr_intrastat_product_declaration_action"
-        model="ir.actions.act_window"
-    >
-        <field name="name">EMEBI</field>
-        <field name="res_model">intrastat.product.declaration</field>
-        <field name="view_mode">list,form,graph,pivot</field>
-    </record>
-    <menuitem
-        id="l10n_fr_intrastat_product_declaration_menu"
-        parent="intrastat_base.menu_intrastat_base_root"
-        action="l10n_fr_intrastat_product_declaration_action"
-        sequence="10"
-    />
 </odoo>


### PR DESCRIPTION
Remove menu entry, because it is now added by the module intrastat_product, cf https://github.com/OCA/intrastat-extrastat/pull/323