### PR TITLE
[17.0][IMP] l10n_fr_intrastat_product: Remove menu entry

### DIFF
--- a/l10n_fr_intrastat_product/views/intrastat_product_declaration.xml
+++ b/l10n_fr_intrastat_product/views/intrastat_product_declaration.xml
@@ -85,19 +85,4 @@
             </field>
         </field>
     </record>
-
-    <record
-        id="l10n_fr_intrastat_product_declaration_action"
-        model="ir.actions.act_window"
-    >
-        <field name="name">EMEBI</field>
-        <field name="res_model">intrastat.product.declaration</field>
-        <field name="view_mode">tree,form,graph,pivot</field>
-    </record>
-    <menuitem
-        id="l10n_fr_intrastat_product_declaration_menu"
-        parent="intrastat_base.menu_intrastat_base_root"
-        action="l10n_fr_intrastat_product_declaration_action"
-        sequence="10"
-    />
 </odoo>


### PR DESCRIPTION
Remove menu entry, because it is now added by the module intrastat_product