### PR TITLE
[FIX] l10n_fr_chorus_account: fix ormcache clearing in _get_token

### DIFF
--- a/l10n_fr_chorus_account/__manifest__.py
+++ b/l10n_fr_chorus_account/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "L10n FR Chorus",
     "summary": "Generate Chorus-compliant e-invoices and transmit them "
     "via the Chorus API",
-    "version": "17.0.2.0.0",
+    "version": "17.0.2.0.1",
     "category": "French Localization",
     "author": "Akretion,Odoo Community Association (OCA)",
     "maintainers": ["alexis-via"],

--- a/l10n_fr_chorus_account/models/res_company.py
+++ b/l10n_fr_chorus_account/models/res_company.py
@@ -234,8 +234,8 @@ class ResCompany(models.Model):
         now = datetime.utcnow()
         logger.debug("_get_token expiry_date_gmt=%s now=%s", expiry_date_gmt, now)
         if now > expiry_date_gmt:
-            # force clear cache
-            self._get_new_token.clear_cache(self.env[self._name])
+            # force clear ormcache for _get_new_token
+            self.env.registry.clear_cache()
             logger.info("PISTE Token cleared from cache.")
             token, expiry_date_gmt = self._get_new_token(
                 api_params["oauth_id"], api_params["oauth_secret"], api_params["qualif"]

--- a/l10n_fr_chorus_account/tests/__init__.py
+++ b/l10n_fr_chorus_account/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_res_company

--- a/l10n_fr_chorus_account/tests/test_res_company.py
+++ b/l10n_fr_chorus_account/tests/test_res_company.py
@@ -1,0 +1,69 @@
+# Copyright 2025 Omydoo (https://www.omydoo.fr)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from odoo.tests.common import TransactionCase
+
+
+class TestResCompanyChorus(TransactionCase):
+    def test_get_token_expired_clears_cache(self):
+        """Test that _get_token clears ormcache when token is expired."""
+        company = self.env.company
+        fake_token = {
+            "access_token": "test_token_123",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": "openid",
+        }
+        expired_date = datetime.utcnow() - timedelta(seconds=10)
+        valid_date = datetime.utcnow() + timedelta(seconds=3600)
+        call_count = {"n": 0}
+
+        def mock_get_new_token(self_model, oauth_id, oauth_secret, qualif):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # First call returns expired token
+                return (fake_token, expired_date)
+            # Second call (after cache clear) returns valid token
+            return (fake_token, valid_date)
+
+        api_params = {
+            "oauth_id": "test_id",
+            "oauth_secret": "test_secret",
+            "qualif": False,
+        }
+
+        with patch.object(type(company), "_get_new_token", mock_get_new_token):
+            token = company._get_token(api_params)
+
+        self.assertEqual(token, fake_token)
+        # _get_new_token must have been called twice:
+        # once with expired result, then again after cache clear
+        self.assertEqual(call_count["n"], 2)
+
+    def test_get_token_valid_no_cache_clear(self):
+        """Test that _get_token does not clear cache when token is valid."""
+        company = self.env.company
+        fake_token = {
+            "access_token": "test_token_456",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": "openid",
+        }
+        valid_date = datetime.utcnow() + timedelta(seconds=3600)
+
+        def mock_get_new_token(self_model, oauth_id, oauth_secret, qualif):
+            return (fake_token, valid_date)
+
+        api_params = {
+            "oauth_id": "test_id",
+            "oauth_secret": "test_secret",
+            "qualif": False,
+        }
+
+        with patch.object(type(company), "_get_new_token", mock_get_new_token):
+            token = company._get_token(api_params)
+
+        self.assertEqual(token, fake_token)


### PR DESCRIPTION
## Description

In Odoo 17, the `ormcache` API changed and decorated methods no longer expose a `clear_cache` attribute. The call to `self._get_new_token.clear_cache(self.env[self._name])` in `_get_token()` raises:

```
AttributeError: 'function' object has no attribute 'clear_cache'
```

This error occurs when the PISTE OAuth token has expired and needs to be refreshed. The `ormcache.clear()` method was deprecated in Odoo 17 (see `odoo/tools/cache.py`), and cache clearing must now go through the registry: `self.env.registry.clear_cache()`.

## Impact

This bug causes the **Chorus Pro cron job** ("Chorus Pro Invoice Status Update") to fail every time the PISTE token expires (typically every hour). On a production instance, we observed:

- The cron runs for 7-8 minutes per execution before hitting this error
- It retries every hour, failing each time during night runs when the token expires
- It holds a database connection open for the entire duration, contributing to connection pool exhaustion

## Fix

Replace:
```python
self._get_new_token.clear_cache(self.env[self._name])
```

With:
```python
self.env.registry.clear_cache()
```

This is consistent with how cache invalidation is done everywhere else in Odoo 17 core (e.g., `res_users.py`, `ir_model.py`, `ir_actions.py`, etc.).

## Version

Bump from `17.0.2.0.0` to `17.0.2.0.1` (patch fix).

Made with [Cursor](https://cursor.com)