### PR TITLE
[FIX] fix l10n_fr_department migration parameter name

### DIFF
--- a/l10n_fr_department/migrations/18.0.2.0.0/post-migration.py
+++ b/l10n_fr_department/migrations/18.0.2.0.0/post-migration.py
@@ -8,7 +8,8 @@ from odoo.addons.l10n_fr_department.model.res_partner import FR_SPECIAL_ZIPCODES
 
 
 @openupgrade.migrate()
-def migrate(env, version):
+def migrate(cr, version):
+    env = cr
     fr_country_id = env.ref("base.fr").id
     partners = env["res.partner"].search(
         [


### PR DESCRIPTION
Odoo only accepts cr as variable name in migrate function