### PR TITLE
[18.0][FIX] account_payment_lcr: tests : validate company bank account

### DIFF
--- a/account_payment_fr_lcr/tests/test_fr_lcr.py
+++ b/account_payment_fr_lcr/tests/test_fr_lcr.py
@@ -108,6 +108,7 @@ class TestFrLcr(AccountTestInvoicingCommon):
                     cls.env.ref("account_payment_base_oca.bank_la_banque_postale").id
                 ),
                 "acc_number": "FR10 1212 2323 3434 4545 4747 676",
+                "allow_out_payment": True,
             }
         )
         cls.bank_journal = cls.env["account.journal"].create(


### PR DESCRIPTION
Fix failing tests for l10n_fr because of modification made by Odoo in https://github.com/odoo/odoo/pull/248108