### PR TITLE
[16.0][FIX] account_balance_ebp_csv_export: Updated report data method name for balance trial report

### DIFF
--- a/account_balance_ebp_csv_export/wizard/trial_balance_wizard.py
+++ b/account_balance_ebp_csv_export/wizard/trial_balance_wizard.py
@@ -10,7 +10,7 @@ class TrialBalanceReportWizard(models.TransientModel):
     _inherit = "trial.balance.report.wizard"
 
     def button_export_ebp_csv(self):
-        data = self._prepare_report_trial_balance()
+        data = self._prepare_report_data()
         ir_report = self.env.ref(
             "account_balance_ebp_csv_export.action_report_trial_balance_ebp"
         )


### PR DESCRIPTION
In this following account-financial-reporting PR ( https://github.com/OCA/account-financial-reporting/pull/1290 ), the abstract wizard model account_financial_report_abstract_wizard got a new generic method "_prepare_report_data", and as such, the "_prepare_report_trial_balance" was changed to a overloading of the "_prepare_report_data" method, with the same data provided.

As such, the previous "_prepare_report_trial_balance" was no longer available, and using this export action lead to a crash due to a non-found method. So, we update the previous data method to the new one.