### PR TITLE
[FIX] l10n_fr_chorus_account: clear cache crash

### DIFF
--- a/l10n_fr_chorus_account/models/res_company.py
+++ b/l10n_fr_chorus_account/models/res_company.py
@@ -240,7 +240,7 @@ class ResCompany(models.Model):
         logger.debug("_get_token expiry_date_gmt=%s now=%s", expiry_date_gmt, now)
         if now > expiry_date_gmt:
             # force clear cache
-            self._get_new_token.clear_cache(self.env[self._name])
+            self.env.registry.clear_cache()
             logger.info("PISTE Token cleared from cache.")
             token, expiry_date_gmt = self._get_new_token(
                 api_params["oauth_id"], api_params["oauth_secret"], api_params["qualif"]


### PR DESCRIPTION
With Odoo 18 and during the chorus.send() method, the token seems to be cleaned from the cache. But this method seems not present in latest Odoo 18 so the page crash with the following error.

Here a small small, I'm not quite sure if clearing the whole cache is the best option, but this fixed the issue on my end.

```
2026-03-16 13:54:40,506 2809202 INFO xxx odoo.addons.l10n_fr_chorus_account.models.account_move: Start to send invoice IDs [1675] via Chorus WS 
2026-03-16 13:54:40,510 2809202 ERROR xxx odoo.http: Exception during request handling. 
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 2576, in __call__
    response = request._serve_db()
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 2103, in _serve_db
    return self._transactioning(
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 2166, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 156, in retrying
    result = func()
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 2133, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 2381, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
    result = endpoint(**request.params)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/dataset.py", line 42, in call_button
    action = call_kw(request.env[model], method, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 535, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "/usr/share/odoo-oca/l10n_fr_chorus_account/wizard/account_invoice_chorus_send.py", line 98, in run
    flow = self.invoice_ids._fr_chorus_send()
  File "/usr/share/odoo-oca/l10n_fr_chorus_account/models/account_move.py", line 374, in _fr_chorus_send
    answer, session = company._chorus_post(api_params, url_path, payload)
  File "/usr/share/odoo-oca/l10n_fr_chorus_account/models/res_company.py", line 267, in _chorus_post
    token = self._get_token(api_params)
  File "/usr/share/odoo-oca/l10n_fr_chorus_account/models/res_company.py", line 243, in _get_token
    self._get_new_token.clear_cache(self.env[self._name])
AttributeError: 'function' object has no attribute 'clear_cache'
2026-03-16 13:54:40,511 2809202 INFO xxx werkzeug: 90.91.229.132 - - [16/Mar/2026 13:54:40] "POST /web/dataset/call_button/account.invoice.chorus.send/run HTTP/1.0" 200 - 70 0.025 2.272