### PR TITLE
[18][FIX][l10n_fr_chorus_account] invoice_sending_method recomputation on invoice in multi-compa,y case

### DIFF
--- a/l10n_fr_chorus_account/models/account_move.py
+++ b/l10n_fr_chorus_account/models/account_move.py
@@ -65,7 +65,9 @@ class AccountMove(models.Model):
     # The related field below should be native... I hope we won't have conflict issues
     # if another module defines the same related field.
     invoice_sending_method = fields.Selection(
-        related="commercial_partner_id.invoice_sending_method", store=True
+        selection="_selection_invoice_sending_method",
+        compute="_compute_invoice_sending_method",
+        store=True,
     )
     chorus_flow_id = fields.Many2one(
         "chorus.flow",
@@ -96,6 +98,19 @@ class AccountMove(models.Model):
         string="Chorus Service Code",
         store=True,
     )
+
+    def _selection_invoice_sending_method(self):
+        return self.env["res.partner"]._fields["invoice_sending_method"].selection
+
+    @api.depends("commercial_partner_id.invoice_sending_method", "company_id")
+    def _compute_invoice_sending_method(self):
+        for move in self:
+            if move.commercial_partner_id:
+                move.invoice_sending_method = move.commercial_partner_id.with_company(
+                    move.company_id
+                ).invoice_sending_method
+            else:
+                move.invoice_sending_method = False
 
     @api.constrains("chorus_attachment_ids", "invoice_sending_method")
     def _check_chorus_attachments(self):


### PR DESCRIPTION
How to reproduce this bug (on ruboat)

Add the chorus API group to the user admin
Beeing loggued on the main company only (san fransico) : create a partner, create an invoice. Then change the `invoice_sending_method` to chorus on the partner.
The `invoice_sending_method` on the invoice IS recomputed, the chorus tab is displayed.

Beeing loggued only on FR company (not the default company of the user), Do exactly the same. But create a new partner, do not use the previous one)
The `invoice_sending_method` is NOT recomputed, the chorus tab is not displayed.
Actually the invoice_sending_method is recomputed but it takes the value of the default company of the user.


Note, I am not sure it is a good thing to recompute `invoice_sending_method` on the invoice (which is presently the case with the related). Because we could have old invoices it makes no sense to recompute.
Maybe it could be better to loop only on draft/cancel invoices and skip recomputation for posted one.

What do you think @alexis-via @LESTRAT21 @bguillot  ?