### PR TITLE
[IMP] l10n_fr_siret: configurable duplicate warning (SIREN/SIRET)

### DIFF
--- a/l10n_fr_siret/__init__.py
+++ b/l10n_fr_siret/__init__.py
@@ -1,2 +1,3 @@
 from . import models
+from . import wizard
 from .post_install import set_siren_nic

--- a/l10n_fr_siret/__manifest__.py
+++ b/l10n_fr_siret/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "French company identity numbers SIRET/SIREN/NIC",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.3.0",
     "category": "French Localization",
     "author": "Numérigraphe,Akretion,Odoo Community Association (OCA)",
     "maintainers": ["alexis-via"],
@@ -16,6 +16,7 @@
     "data": [
         "views/res_partner.xml",
         "views/res_company.xml",
+        "wizard/res_config_settings.xml",
     ],
     "demo": ["demo/partner_demo.xml"],
     "post_init_hook": "set_siren_nic",

--- a/l10n_fr_siret/i18n/bg.po
+++ b/l10n_fr_siret/i18n/bg.po
@@ -30,13 +30,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -62,6 +91,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -69,6 +99,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -77,6 +108,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -145,7 +197,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/i18n/cs_CZ.po
+++ b/l10n_fr_siret/i18n/cs_CZ.po
@@ -11,8 +11,8 @@ msgstr ""
 "POT-Creation-Date: 2018-02-22 03:41+0000\n"
 "PO-Revision-Date: 2018-02-22 03:41+0000\n"
 "Last-Translator: Lukáš Spurný <lukasspurny8@gmail.com>, 2018\n"
-"Language-Team: Czech (Czech Republic) (https://www.transifex.com/oca/"
-"teams/23907/cs_CZ/)\n"
+"Language-Team: Czech (Czech Republic) (https://www.transifex.com/oca/teams/"
+"23907/cs_CZ/)\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,13 +31,42 @@ msgid "Companies"
 msgstr "Společnosti"
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr "Kontakt"
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -63,6 +92,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr "SIRÉNA"
 
@@ -70,6 +100,7 @@ msgstr "SIRÉNA"
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 #, fuzzy
 msgid "SIRET"
 msgstr "SIRÉNA"
@@ -79,6 +110,29 @@ msgstr "SIRÉNA"
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+#, fuzzy
+msgid "Same SIREN"
+msgstr "SIRÉNA"
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+#, fuzzy
+msgid "Same SIRET"
+msgstr "SIRÉNA"
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -154,7 +208,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Company Registry"

--- a/l10n_fr_siret/i18n/da.po
+++ b/l10n_fr_siret/i18n/da.po
@@ -30,13 +30,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -62,6 +91,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -69,6 +99,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -77,6 +108,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -145,7 +197,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/i18n/de.po
+++ b/l10n_fr_siret/i18n/de.po
@@ -30,13 +30,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -62,6 +91,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -69,6 +99,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -77,6 +108,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -145,7 +197,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/i18n/el_GR.po
+++ b/l10n_fr_siret/i18n/el_GR.po
@@ -31,13 +31,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -63,6 +92,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -70,6 +100,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -78,6 +109,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -146,7 +198,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/i18n/es.po
+++ b/l10n_fr_siret/i18n/es.po
@@ -33,14 +33,44 @@ msgid "Companies"
 msgstr "Compañías"
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr "Contacto"
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+#, fuzzy
+msgid "Duplicate Partner Check"
+msgstr "Aviso de duplicado: socio"
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
 msgstr "Aviso de duplicado: socio"
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
+msgstr ""
 
 #. module: l10n_fr_siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
@@ -65,6 +95,7 @@ msgstr "Socio con el mismo SIREN"
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr "SIREN"
 
@@ -72,6 +103,7 @@ msgstr "SIREN"
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr "SIRET"
 
@@ -81,6 +113,29 @@ msgstr "SIRET"
 #, python-format
 msgid "SIRET '%s' is invalid."
 msgstr "SIRET '%s' es inválido."
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+#, fuzzy
+msgid "Same SIREN"
+msgstr "SIREN"
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+#, fuzzy
+msgid "Same SIRET"
+msgstr "SIRET"
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
+msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
@@ -163,7 +218,19 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#, fuzzy
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr "tiene el mismo <b>SIREN</b>."
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr "tiene el mismo <b>SIREN</b>."
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+#, fuzzy
+msgid "has the same <b>SIRET</b>."
 msgstr "tiene el mismo <b>SIREN</b>."
 
 #~ msgid "Company ID"

--- a/l10n_fr_siret/i18n/es_MX.po
+++ b/l10n_fr_siret/i18n/es_MX.po
@@ -31,13 +31,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -63,6 +92,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -70,6 +100,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -78,6 +109,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -146,7 +198,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/i18n/fi.po
+++ b/l10n_fr_siret/i18n/fi.po
@@ -30,13 +30,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -62,6 +91,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -69,6 +99,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -77,6 +108,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -145,7 +197,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/i18n/fr.po
+++ b/l10n_fr_siret/i18n/fr.po
@@ -29,14 +29,45 @@ msgid "Companies"
 msgstr "Sociétés"
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr "Contact"
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr "Détection de doublons de partenaires"
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
 msgstr "Avertissement doublon: le partenaire"
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr "Champ utilisé pour détecter les partenaires en doublon"
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+"Champ utilisé pour détecter les partenaires en doublon : SIREN (niveau "
+"société) ou SIRET (niveau établissement)."
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
+msgstr "Localisation française"
 
 #. module: l10n_fr_siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
@@ -61,6 +92,7 @@ msgstr "Partenaire avec SIREN identique"
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr "SIREN"
 
@@ -68,6 +100,7 @@ msgstr "SIREN"
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr "SIRET"
 
@@ -77,6 +110,27 @@ msgstr "SIRET"
 #, python-format
 msgid "SIRET '%s' is invalid."
 msgstr "Le SIRET '%s' est invalide."
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr "Même SIREN"
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr "Même SIREN sans NIC"
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr "Même SIRET"
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
+msgstr "Type de correspondance de partenaire même SIREN"
 
 #. module: l10n_fr_siret
 #. odoo-python
@@ -151,8 +205,18 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr "a le même <b>SIREN</b> (sans NIC)."
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
 msgstr "a le même <b>SIREN</b>."
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
+msgstr "a le même <b>SIRET</b>."
 
 #~ msgid "Company Registry"
 #~ msgstr "RCS"

--- a/l10n_fr_siret/i18n/fr_CH.po
+++ b/l10n_fr_siret/i18n/fr_CH.po
@@ -11,8 +11,8 @@ msgstr ""
 "POT-Creation-Date: 2017-01-17 03:38+0000\n"
 "PO-Revision-Date: 2017-01-17 03:38+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: French (Switzerland) (https://www.transifex.com/oca/"
-"teams/23907/fr_CH/)\n"
+"Language-Team: French (Switzerland) (https://www.transifex.com/oca/teams/"
+"23907/fr_CH/)\n"
 "Language: fr_CH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,13 +31,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -63,6 +92,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -70,6 +100,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -78,6 +109,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -146,7 +198,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/i18n/hr.po
+++ b/l10n_fr_siret/i18n/hr.po
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 #. module: l10n_fr_siret
 #: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
@@ -31,13 +31,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -63,6 +92,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -70,6 +100,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -78,6 +109,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -146,7 +198,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/i18n/it.po
+++ b/l10n_fr_siret/i18n/it.po
@@ -30,13 +30,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -62,6 +91,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -69,6 +99,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -77,6 +108,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -145,7 +197,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/i18n/l10n_fr_siret.pot
+++ b/l10n_fr_siret/i18n/l10n_fr_siret.pot
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -14,8 +14,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company model:ir.model.fields,help:l10n_fr_siret.field_res_users__parent_is_company
 msgid "Check if the contact is a company, otherwise it is a person"
 msgstr ""
 
@@ -25,8 +24,18 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -35,35 +44,42 @@ msgid "Duplicate warning: partner"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Field used to detect duplicate partners: SIREN (company level) or SIRET (establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__nic model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__nic model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__nic
 msgid "NIC"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__parent_is_company model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__parent_is_company
 msgid "Parent is a Company"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_id
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_id
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_id model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_id
 msgid "Partner with same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -75,70 +91,79 @@ msgid "SIRET '%s' is invalid."
 msgstr ""
 
 #. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-#, python-format
-msgid ""
-"The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 5 digits."
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
-msgid ""
-"The NIC number is the official rank number of this office in the company in "
-"France. It composes the last 5 digits of the SIRET number."
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
 msgstr ""
 
 #. module: l10n_fr_siret
-#. odoo-python
-#: code:addons/l10n_fr_siret/models/res_partner.py:0
-#, python-format
-msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have "
-"exactly 9 digits."
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
-msgid ""
-"The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+msgid "The NIC '{nic}' of partner '{partner_name}' is incorrect: it must have exactly 5 digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
-msgid ""
-"The SIREN number is the official identity number of the company in France. "
-"It composes the first 9 digits of the SIRET number."
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__nic model:ir.model.fields,help:l10n_fr_siret.field_res_partner__nic model:ir.model.fields,help:l10n_fr_siret.field_res_users__nic
+msgid "The NIC number is the official rank number of this office in the company in France. It composes the last 5 digits of the SIRET number."
 msgstr ""
 
 #. module: l10n_fr_siret
 #. odoo-python
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
-msgid ""
-"The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is "
-"wrong."
+msgid "The SIREN '{siren}' of partner '{partner_name}' is incorrect: it must have exactly 9 digits."
 msgstr ""
 
 #. module: l10n_fr_siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret
-#: model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
-msgid ""
-"The SIRET number is the official identity number of this company's office in"
-" France. It is composed of the 9 digits of the SIREN number and the 5 digits"
-" of the NIC number, ie. 14 digits."
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#, python-format
+msgid "The SIREN '{siren}' of partner '{partner_name}' is invalid: the checksum is wrong."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siren model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siren model:ir.model.fields,help:l10n_fr_siret.field_res_users__siren
+msgid "The SIREN number is the official identity number of the company in France. It composes the first 9 digits of the SIRET number."
+msgstr ""
+
+#. module: l10n_fr_siret
+#. odoo-python
+#: code:addons/l10n_fr_siret/models/res_partner.py:0
+#, python-format
+msgid "The SIRET '{siret}' of partner '{partner_name}' is invalid: the checksum is wrong."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__siret model:ir.model.fields,help:l10n_fr_siret.field_res_partner__siret model:ir.model.fields,help:l10n_fr_siret.field_res_users__siret
+msgid "The SIRET number is the official identity number of this company's office in France. It is composed of the 9 digits of the SIREN number and the 5 digits of the NIC number, ie. 14 digits."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
 msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""

--- a/l10n_fr_siret/i18n/nb_NO.po
+++ b/l10n_fr_siret/i18n/nb_NO.po
@@ -31,13 +31,42 @@ msgid "Companies"
 msgstr "Firmaer"
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -63,6 +92,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -70,6 +100,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -78,6 +109,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -146,7 +198,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Company Registry"

--- a/l10n_fr_siret/i18n/nl.po
+++ b/l10n_fr_siret/i18n/nl.po
@@ -30,13 +30,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -62,6 +91,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -69,6 +99,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -77,6 +108,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -145,7 +197,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/i18n/pt.po
+++ b/l10n_fr_siret/i18n/pt.po
@@ -30,13 +30,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -62,6 +91,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -69,6 +99,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -77,6 +108,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -145,7 +197,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/i18n/pt_BR.po
+++ b/l10n_fr_siret/i18n/pt_BR.po
@@ -11,8 +11,8 @@ msgstr ""
 "POT-Creation-Date: 2017-01-17 03:38+0000\n"
 "PO-Revision-Date: 2017-01-17 03:38+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/"
-"teams/23907/pt_BR/)\n"
+"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/teams/"
+"23907/pt_BR/)\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,13 +31,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -63,6 +92,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -70,6 +100,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -78,6 +109,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -146,7 +198,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/i18n/sl.po
+++ b/l10n_fr_siret/i18n/sl.po
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3);\n"
 
 #. module: l10n_fr_siret
 #: model:ir.model.fields,help:l10n_fr_siret.field_res_partner__parent_is_company
@@ -31,13 +31,42 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model,name:l10n_fr_siret.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model:ir.model,name:l10n_fr_siret.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid "Duplicate Partner Check"
+msgstr ""
+
+#. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "Duplicate warning: partner"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "Field used to detect duplicate partners"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_company__fr_siret_dup_check
+#: model:ir.model.fields,help:l10n_fr_siret.field_res_config_settings__fr_siret_dup_check
+msgid ""
+"Field used to detect duplicate partners: SIREN (company level) or SIRET "
+"(establishment level)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_config_settings_view_form
+msgid "French Localization"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -63,6 +92,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siren
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siren
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siren
 msgid "SIREN"
 msgstr ""
 
@@ -70,6 +100,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_company__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__siret
 #: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_company__fr_siret_dup_check__siret
 msgid "SIRET"
 msgstr ""
 
@@ -78,6 +109,27 @@ msgstr ""
 #: code:addons/l10n_fr_siret/models/res_partner.py:0
 #, python-format
 msgid "SIRET '%s' is invalid."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren
+msgid "Same SIREN"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siren_no_nic
+msgid "Same SIREN without NIC"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields.selection,name:l10n_fr_siret.selection__res_partner__same_siren_partner_match_type__siret
+msgid "Same SIRET"
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_partner__same_siren_partner_match_type
+#: model:ir.model.fields,field_description:l10n_fr_siret.field_res_users__same_siren_partner_match_type
+msgid "Same Siren Partner Match Type"
 msgstr ""
 
 #. module: l10n_fr_siret
@@ -146,7 +198,17 @@ msgstr ""
 
 #. module: l10n_fr_siret
 #: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIREN</b> (no NIC set)."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
 msgid "has the same <b>SIREN</b>."
+msgstr ""
+
+#. module: l10n_fr_siret
+#: model_terms:ir.ui.view,arch_db:l10n_fr_siret.res_partner_form_l10n_fr
+msgid "has the same <b>SIRET</b>."
 msgstr ""
 
 #~ msgid "Partner"

--- a/l10n_fr_siret/models/res_company.py
+++ b/l10n_fr_siret/models/res_company.py
@@ -18,3 +18,11 @@ class ResCompany(models.Model):
     nic = fields.Char(
         string="NIC", related="partner_id.nic", store=True, readonly=False
     )
+    fr_siret_dup_check = fields.Selection(
+        [("siren", "SIREN"), ("siret", "SIRET")],
+        string="Duplicate Partner Check",
+        default="siren",
+        required=True,
+        help="Field used to detect duplicate partners: SIREN (company level) "
+        "or SIRET (establishment level).",
+    )

--- a/l10n_fr_siret/models/res_partner.py
+++ b/l10n_fr_siret/models/res_partner.py
@@ -135,17 +135,34 @@ class Partner(models.Model):
         string="Partner with same SIREN",
         compute_sudo=True,
     )
+    same_siren_partner_match_type = fields.Selection(
+        [
+            ("siren", "Same SIREN"),
+            ("siret", "Same SIRET"),
+            ("siren_no_nic", "Same SIREN without NIC"),
+        ],
+        compute="_compute_same_siren_partner_id",
+        compute_sudo=True,
+    )
 
-    @api.depends("siren", "company_id")
+    @api.depends("siren", "nic", "company_id")
     def _compute_same_siren_partner_id(self):
         # Inspired by same_vat_partner_id from 'base' module
         for partner in self:
             same_siren_partner_id = False
+            match_type = False
+            company = partner.company_id or self.env.company
+            dup_check = company.fr_siret_dup_check
             if partner.siren and not partner.parent_id:
-                domain = [
-                    ("siren", "=", partner.siren),
-                    ("parent_id", "=", False),
-                ]
+                domain = [("parent_id", "=", False), ("siren", "=", partner.siren)]
+                if dup_check == "siret":
+                    if partner.nic:
+                        domain.append(("nic", "=", partner.nic))
+                        match_type = "siret"
+                    else:
+                        match_type = "siren_no_nic"
+                else:
+                    match_type = "siren"
                 if partner.company_id:
                     domain += [
                         "|",
@@ -160,3 +177,6 @@ class Partner(models.Model):
                     self.with_context(active_test=False).search(domain, limit=1)
                 ).id or False
             partner.same_siren_partner_id = same_siren_partner_id
+            partner.same_siren_partner_match_type = (
+                match_type if same_siren_partner_id else False
+            )

--- a/l10n_fr_siret/views/res_partner.xml
+++ b/l10n_fr_siret/views/res_partner.xml
@@ -47,14 +47,33 @@
                 attrs="{'invisible': [('same_vat_partner_id', '=', False)]}"
                 position="after"
             >
+                <field name="same_siren_partner_match_type" invisible="1" />
                 <div
                     class="alert alert-warning"
                     role="alert"
-                    attrs="{'invisible': [('same_siren_partner_id', '=', False)]}"
+                    attrs="{'invisible': [('same_siren_partner_match_type', '!=', 'siren')]}"
                 >
                         Duplicate warning: partner <field
                         name="same_siren_partner_id"
                     /> has the same <b>SIREN</b>.
+                </div>
+                <div
+                    class="alert alert-warning"
+                    role="alert"
+                    attrs="{'invisible': [('same_siren_partner_match_type', '!=', 'siret')]}"
+                >
+                        Duplicate warning: partner <field
+                        name="same_siren_partner_id"
+                    /> has the same <b>SIRET</b>.
+                </div>
+                <div
+                    class="alert alert-warning"
+                    role="alert"
+                    attrs="{'invisible': [('same_siren_partner_match_type', '!=', 'siren_no_nic')]}"
+                >
+                        Duplicate warning: partner <field
+                        name="same_siren_partner_id"
+                    /> has the same <b>SIREN</b> (no NIC set).
                 </div>
             </div>
         </field>

--- a/l10n_fr_siret/wizard/__init__.py
+++ b/l10n_fr_siret/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import res_config_settings

--- a/l10n_fr_siret/wizard/res_config_settings.py
+++ b/l10n_fr_siret/wizard/res_config_settings.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    fr_siret_dup_check = fields.Selection(
+        related="company_id.fr_siret_dup_check", readonly=False
+    )

--- a/l10n_fr_siret/wizard/res_config_settings.xml
+++ b/l10n_fr_siret/wizard/res_config_settings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">l10n_fr_siret.res.config.settings.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div id="invoicing_settings" position="after">
+                <h2>French Localization</h2>
+                <div class="row mt16 o_settings_container" id="l10n_fr_siret">
+                    <div class="col-xs-12 col-md-6 o_setting_box">
+                        <div class="o_setting_left_pane" />
+                        <div class="o_setting_right_pane">
+                            <label for="fr_siret_dup_check" />
+                            <div class="text-muted">
+                                Field used to detect duplicate partners
+                            </div>
+                            <field name="fr_siret_dup_check" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
It is reasonable to have different top-level partners with the same SIREN, while same SIRET would be a duplicate.
This allows to choose what duplicate check should be performed.