### PR TITLE
[14.0][FIX] l10n_fr_das2: drop obsolete config settings view on upgrade

### DIFF
--- a/l10n_fr_das2/__manifest__.py
+++ b/l10n_fr_das2/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "DAS2",
-    "version": "14.0.4.0.0",
+    "version": "14.0.4.0.1",
     "category": "Invoicing Management",
     "license": "AGPL-3",
     "summary": "DAS2 (France)",

--- a/l10n_fr_das2/migrations/14.0.4.0.1/pre-migration.py
+++ b/l10n_fr_das2/migrations/14.0.4.0.1/pre-migration.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Altixia (https://www.altixia.com)
+# @author: Claude Perrin <claude@altixia.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    # The 'fr_das2_partner_declare_threshold' setting field was removed in
+    # v14.0.4.0.0 (the declaration threshold is now provided by the pyfrdas2
+    # lib). Its res.config.settings view 'view_account_config_settings' was
+    # removed from the module too, but the stale DB record keeps referencing
+    # the dropped field. During an upgrade, as soon as another module
+    # re-renders res.config.settings, view validation raises
+    # "Field 'fr_das2_partner_declare_threshold' does not exist in model
+    # 'res.config.settings'" and the registry fails to load. Odoo would
+    # eventually drop the orphan view in _process_end, but the crash happens
+    # before that. Drop the obsolete view here, before the views are reloaded.
+    cr.execute(
+        """
+        DELETE FROM ir_ui_view
+        WHERE id IN (
+            SELECT res_id
+            FROM ir_model_data
+            WHERE module = 'l10n_fr_das2'
+              AND model = 'ir.ui.view'
+              AND name = 'view_account_config_settings'
+        )
+        """
+    )


### PR DESCRIPTION
## Problem

`l10n_fr_das2` v14.0.4.0.0 removed the `fr_das2_partner_declare_threshold` setting field (the declaration threshold now comes from the `pyfrdas2` lib) together with its `res.config.settings` view `view_account_config_settings` — but **without a migration** to clean up the stale view record left in the database.

On upgrade from an earlier version, as soon as any other module re-renders the `res.config.settings` form (e.g. a module extending the accounting/general settings), view validation fails with:

> ValidationError: Field 'fr_das2_partner_declare_threshold' does not exist in model 'res.config.settings'

and the registry fails to load (the whole `-u` rolls back). Odoo would normally drop the orphan view in `_process_end`, but the crash happens earlier, while reloading the views.

## Solution

Add a `pre-migration.py` (version bumped to `14.0.4.0.1`) that drops the obsolete view **before** the views are reloaded:

- `l10n_fr_das2/migrations/14.0.4.0.1/pre-migration.py`

## Testing

Reproduced and fixed on a real production database (Odoo 14.0, `-u all`): without the cleanup the upgrade crashes on the obsolete view; removing it beforehand lets the upgrade complete with no error.
