### PR TITLE
[19.0][FIX] l10n_fr_pos_caisse_ap_ip: robustness of the payment terminal exchange + translations #1

### DIFF
--- a/l10n_fr_pos_caisse_ap_ip/i18n/es.po
+++ b/l10n_fr_pos_caisse_ap_ip/i18n/es.po
@@ -53,8 +53,8 @@ msgid ""
 "Caisse AP IP protocol: tag %s is required but it is not present in the "
 "answer from the terminal. This should never happen!"
 msgstr ""
-"Caisse AP IP protocol: tag %s is required but it is not present in the "
-"answer from the terminal. ¡Esto no debería ocurrir nunca!"
+"Protocolo Caisse AP IP: la etiqueta %s es obligatoria pero no está presente "
+"en la respuesta del terminal. ¡Esto no debería ocurrir nunca!"
 
 #. module: l10n_fr_pos_caisse_ap_ip
 #. odoo-python
@@ -88,6 +88,12 @@ msgid "Caisse-AP payment terminal port is not set on payment method '%s'."
 msgstr ""
 "El puerto del terminal de pago Caisse-AP no está configurado en el método de "
 "pago '%s'."
+
+#. module: l10n_fr_pos_caisse_ap_ip
+#. odoo-python
+#: code:addons/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py:0
+msgid "Cannot understand the answer from the payment terminal: %s"
+msgstr "No se puede entender la respuesta del terminal de pago: %s"
 
 #. module: l10n_fr_pos_caisse_ap_ip
 #: model:ir.model.fields.selection,name:l10n_fr_pos_caisse_ap_ip.selection__pos_payment_method__fr_caisse_ap_ip_mode__card
@@ -128,6 +134,8 @@ msgid ""
 "Failure in the connection to the payment terminal on %(ip_addr)s port "
 "%(port)s: %(error)s."
 msgstr ""
+"Fallo en la conexión con el terminal de pago en %(ip_addr)s puerto "
+"%(port)s: %(error)s."
 
 #. module: l10n_fr_pos_caisse_ap_ip
 #: model:ir.model.fields,help:l10n_fr_pos_caisse_ap_ip.field_pos_payment_method__fr_caisse_ap_ip_address
@@ -143,6 +151,16 @@ msgstr ""
 #: code:addons/l10n_fr_pos_caisse_ap_ip/static/src/app/payment_caisse_ap_ip.esm.js:0
 msgid "No answer from the payment terminal in the given time."
 msgstr "No hay respuesta del terminal de pago en el tiempo dado."
+
+#. module: l10n_fr_pos_caisse_ap_ip
+#. odoo-python
+#: code:addons/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py:0
+msgid ""
+"Odoo could not prepare the message for the payment terminal. Check the Odoo "
+"server logs for more details."
+msgstr ""
+"Odoo no pudo preparar el mensaje para el terminal de pago. Consulte los "
+"registros del servidor Odoo para más detalles."
 
 #. module: l10n_fr_pos_caisse_ap_ip
 #: model:ir.model.fields,field_description:l10n_fr_pos_caisse_ap_ip.field_pos_payment_method__fr_caisse_ap_ip_mode

--- a/l10n_fr_pos_caisse_ap_ip/i18n/fr.po
+++ b/l10n_fr_pos_caisse_ap_ip/i18n/fr.po
@@ -42,6 +42,9 @@ msgid ""
 "the request and %(answer_val)s in the answer, but these values should be "
 "identical. This should never happen!"
 msgstr ""
+"Protocole Caisse AP sur IP : Le tag %(label)s (%(tag)s) a pour valeur "
+"%(request_val)s dans la requête et %(answer_val)s dans la réponse, alors que "
+"ces valeurs devraient être identiques. Cela ne devrait jamais arriver !"
 
 #. module: l10n_fr_pos_caisse_ap_ip
 #. odoo-python
@@ -87,6 +90,12 @@ msgstr ""
 "paiement '%s'."
 
 #. module: l10n_fr_pos_caisse_ap_ip
+#. odoo-python
+#: code:addons/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py:0
+msgid "Cannot understand the answer from the payment terminal: %s"
+msgstr "Impossible de comprendre la réponse du terminal de paiement : %s"
+
+#. module: l10n_fr_pos_caisse_ap_ip
 #: model:ir.model.fields.selection,name:l10n_fr_pos_caisse_ap_ip.selection__pos_payment_method__fr_caisse_ap_ip_mode__card
 msgid "Card"
 msgstr "Carte"
@@ -100,7 +109,7 @@ msgstr "Type de carte : %s"
 #. module: l10n_fr_pos_caisse_ap_ip
 #: model:ir.model.fields.selection,name:l10n_fr_pos_caisse_ap_ip.selection__pos_payment_method__fr_caisse_ap_ip_mode__check
 msgid "Check"
-msgstr "Vérifier"
+msgstr "Chèque"
 
 #. module: l10n_fr_pos_caisse_ap_ip
 #. odoo-python
@@ -126,6 +135,8 @@ msgid ""
 "Failure in the connection to the payment terminal on %(ip_addr)s port "
 "%(port)s: %(error)s."
 msgstr ""
+"Échec de la connexion au terminal de paiement sur %(ip_addr)s port "
+"%(port)s : %(error)s."
 
 #. module: l10n_fr_pos_caisse_ap_ip
 #: model:ir.model.fields,help:l10n_fr_pos_caisse_ap_ip.field_pos_payment_method__fr_caisse_ap_ip_address
@@ -141,6 +152,16 @@ msgstr ""
 #: code:addons/l10n_fr_pos_caisse_ap_ip/static/src/app/payment_caisse_ap_ip.esm.js:0
 msgid "No answer from the payment terminal in the given time."
 msgstr "Pas de réponse du terminal de paiement dans le délai imparti."
+
+#. module: l10n_fr_pos_caisse_ap_ip
+#. odoo-python
+#: code:addons/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py:0
+msgid ""
+"Odoo could not prepare the message for the payment terminal. Check the Odoo "
+"server logs for more details."
+msgstr ""
+"Odoo n'a pas pu préparer le message pour le terminal de paiement. Consultez "
+"les logs du serveur Odoo pour plus de détails."
 
 #. module: l10n_fr_pos_caisse_ap_ip
 #: model:ir.model.fields,field_description:l10n_fr_pos_caisse_ap_ip.field_pos_payment_method__fr_caisse_ap_ip_mode

--- a/l10n_fr_pos_caisse_ap_ip/i18n/l10n_fr_pos_caisse_ap_ip.pot
+++ b/l10n_fr_pos_caisse_ap_ip/i18n/l10n_fr_pos_caisse_ap_ip.pot
@@ -75,6 +75,12 @@ msgid "Caisse-AP payment terminal port is not set on payment method '%s'."
 msgstr ""
 
 #. module: l10n_fr_pos_caisse_ap_ip
+#. odoo-python
+#: code:addons/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py:0
+msgid "Cannot understand the answer from the payment terminal: %s"
+msgstr ""
+
+#. module: l10n_fr_pos_caisse_ap_ip
 #: model:ir.model.fields.selection,name:l10n_fr_pos_caisse_ap_ip.selection__pos_payment_method__fr_caisse_ap_ip_mode__card
 msgid "Card"
 msgstr ""
@@ -133,6 +139,14 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/l10n_fr_pos_caisse_ap_ip/static/src/app/utils/payment/payment_caisse_ap_ip.esm.js:0
 msgid "No answer from the payment terminal in the given time."
+msgstr ""
+
+#. module: l10n_fr_pos_caisse_ap_ip
+#. odoo-python
+#: code:addons/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py:0
+msgid ""
+"Odoo could not prepare the message for the payment terminal. Check the Odoo "
+"server logs for more details."
 msgstr ""
 
 #. module: l10n_fr_pos_caisse_ap_ip

--- a/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py
+++ b/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py
@@ -4,6 +4,7 @@
 
 import logging
 import socket
+import time
 
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
@@ -16,6 +17,12 @@ except ImportError:
     logger.debug("Cannot import pycountry")
 
 BUFFER_SIZE = 1024
+# The Caisse-AP protocol has no length header nor end-of-message marker.
+# When the buffer parses as a whole number of fields, we drain the socket
+# during DRAIN_TIMEOUT to catch an answer split exactly on a field boundary.
+DRAIN_TIMEOUT = 0.3
+# Safety cap: a real Caisse-AP answer is well under a few KB
+MAX_ANSWER_SIZE = 65536
 
 
 class PosPaymentMethod(models.Model):
@@ -220,14 +227,40 @@ class PosPaymentMethod(models.Model):
             with socket.create_connection((ip_addr, port), timeout=timeout_sec) as sock:
                 sock.sendall(msg_bytes)
                 # The answer may be split across several TCP packets and may
-                # exceed BUFFER_SIZE: read until the message is complete
+                # exceed BUFFER_SIZE: read until the terminal closes the
+                # connection or the message is complete. As the protocol has
+                # no length header, 'complete' can be a false positive when
+                # the split falls on a field boundary: when the buffer looks
+                # complete, keep reading with a short timeout (DRAIN_TIMEOUT)
+                # and only stop when no more data arrives.
+                deadline = time.monotonic() + timeout_sec
                 while True:
-                    chunk = sock.recv(BUFFER_SIZE)
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            "Global timeout reading the answer from the "
+                            "payment terminal"
+                        )
+                    try:
+                        chunk = sock.recv(BUFFER_SIZE)
+                    except TimeoutError:
+                        if answer and self._fr_caisse_ap_ip_answer_complete(answer):
+                            # Drain timeout expired without extra data:
+                            # the answer is really complete
+                            break
+                        raise
                     if not chunk:
+                        # The terminal closed the connection
                         break
                     answer += chunk.decode("ascii")
+                    if len(answer) > MAX_ANSWER_SIZE:
+                        raise ValueError(
+                            "Answer from the payment terminal exceeds "
+                            f"{MAX_ANSWER_SIZE} bytes"
+                        )
                     if self._fr_caisse_ap_ip_answer_complete(answer):
-                        break
+                        sock.settimeout(DRAIN_TIMEOUT)
+                    else:
+                        sock.settimeout(max(deadline - time.monotonic(), DRAIN_TIMEOUT))
                 logger.debug("Answer received from payment terminal: %s", answer)
         except Exception as e:
             logger.warning("Exception raised in socket to payment terminal: %s", e)

--- a/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py
+++ b/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py
@@ -75,13 +75,17 @@ class PosPaymentMethod(models.Model):
                     )
 
     def _fr_caisse_ap_ip_prepare_msg(self, msg_dict):
-        assert isinstance(msg_dict, dict)
+        # Explicit checks instead of assert, so that they are not
+        # skipped when Python runs in optimized mode (-O)
+        if not isinstance(msg_dict, dict):
+            raise ValueError("msg_dict must be a dict")
         for tag, value in msg_dict.items():
-            assert isinstance(tag, str)
-            assert len(tag) == 2
-            assert isinstance(value, str)
-            assert len(value) >= 1
-            assert len(value) <= 999
+            if not isinstance(tag, str) or len(tag) != 2:
+                raise ValueError(f"Tag {tag!r} must be a string of 2 chars")
+            if not isinstance(value, str) or not 1 <= len(value) <= 999:
+                raise ValueError(
+                    f"Value {value!r} of tag '{tag}' must be a string of 1 to 999 chars"
+                )
         msg_list = []
         # CZ tag: protocol version
         # Always start with tag CZ
@@ -90,7 +94,8 @@ class PosPaymentMethod(models.Model):
             version = msg_dict.pop("CZ")
         else:
             version = "0300"  # 0301 ??
-        assert len(version) == 4
+        if len(version) != 4:
+            raise ValueError(f"Version {version!r} must be a string of 4 chars")
         msg_list.append(("CZ", version))
         msg_list += list(msg_dict.items())
         msg_str = "".join(
@@ -156,10 +161,7 @@ class PosPaymentMethod(models.Model):
             amount_cent = amount_positive
         amount_str = str(int(round(amount_cent)))
         data["amount_str"] = amount_str
-        msg_dict["CB"] = amount_str
-        if len(amount_str) < 2:
-            amount_str = amount_str.zfill(2)
-        elif len(amount_str) > 12:
+        if len(amount_str) > 12:
             logger.error("Amount with cents %s is over the maximum.", amount_str)
             error_msg = self.env._(
                 "You are tying to send amount %s cents to the payment terminal, "
@@ -171,6 +173,8 @@ class PosPaymentMethod(models.Model):
                 "error_message": error_msg,
             }
             return res
+        # The protocol requires a minimum size of 2 chars for the CB tag
+        msg_dict["CB"] = amount_str.zfill(2)
         if self.fr_caisse_ap_ip_mode == "check":
             msg_dict["CC"] = "00C"
         return msg_dict
@@ -182,6 +186,17 @@ class PosPaymentMethod(models.Model):
         payment_method_id = data["payment_method_id"]
         payment_method = self.browse(payment_method_id)
         msg_dict = payment_method._fr_caisse_ap_ip_prepare_message(data)
+        if not msg_dict:
+            return {
+                "payment_status": "issue",
+                "error_message": self.env._(
+                    "Odoo could not prepare the message for the payment terminal. "
+                    "Check the Odoo server logs for more details."
+                ),
+            }
+        if msg_dict.get("payment_status"):
+            # _fr_caisse_ap_ip_prepare_message() returned an error dict
+            return msg_dict
         msg_str = self._fr_caisse_ap_ip_prepare_msg(msg_dict)
         msg_bytes = msg_str.encode("ascii")
         timeout_ms = data["timeout"]
@@ -200,12 +215,19 @@ class PosPaymentMethod(models.Model):
             port,
         )
         logger.debug("Data about to be sent to payment terminal: %s", msg_str)
-        answer = False
+        answer = ""
         try:
             with socket.create_connection((ip_addr, port), timeout=timeout_sec) as sock:
-                sock.send(msg_bytes)
-                answer_bytes = sock.recv(BUFFER_SIZE)
-                answer = answer_bytes.decode("ascii")
+                sock.sendall(msg_bytes)
+                # The answer may be split across several TCP packets and may
+                # exceed BUFFER_SIZE: read until the message is complete
+                while True:
+                    chunk = sock.recv(BUFFER_SIZE)
+                    if not chunk:
+                        break
+                    answer += chunk.decode("ascii")
+                    if self._fr_caisse_ap_ip_answer_complete(answer):
+                        break
                 logger.debug("Answer received from payment terminal: %s", answer)
         except Exception as e:
             logger.warning("Exception raised in socket to payment terminal: %s", e)
@@ -222,7 +244,21 @@ class PosPaymentMethod(models.Model):
             }
             return res
         if answer:
-            res = self._fr_caisse_ap_ip_answer(answer, msg_dict)
+            try:
+                res = self._fr_caisse_ap_ip_answer(answer, msg_dict)
+            except Exception as e:
+                logger.error(
+                    "Cannot parse the answer '%s' from the payment terminal: %s",
+                    answer,
+                    e,
+                )
+                res = {
+                    "payment_status": "issue",
+                    "error_message": self.env._(
+                        "Cannot understand the answer from the payment terminal: %s",
+                        answer,
+                    ),
+                }
         else:
             res = {
                 "payment_status": "issue",
@@ -271,7 +307,7 @@ class PosPaymentMethod(models.Model):
                     "Caisse AP IP protocol: tag %s is required but it is "
                     "not present in the answer from the terminal. "
                     "This should never happen!",
-                    answer_dict.get(tag),
+                    tag,
                 )
                 return fail_res
             if (
@@ -291,8 +327,10 @@ class PosPaymentMethod(models.Model):
                 )
                 return fail_res
             elif not props["fixed_size"] and answer_dict.get(tag):
+                # Strip the leading zeros on both sides: the terminal may
+                # zero-pad the value differently from the request
                 strip_answer = answer_dict[tag].lstrip("0")
-                if msg_dict[tag] != strip_answer:
+                if msg_dict[tag].lstrip("0") != strip_answer:
                     fail_res["error_message"] = self.env._(
                         "Caisse AP IP protocol: Tag %(label)s (%(tag)s) has value "
                         "%(request_val)s in the request and %(answer_val)s in the "
@@ -403,6 +441,19 @@ class PosPaymentMethod(models.Model):
         logger.info("Failure answer from payment terminal (failure report: %s)", label)
         return res
 
+    @api.model
+    def _fr_caisse_ap_ip_answer_complete(self, data_str):
+        # A Caisse-AP message is a sequence of TAG(2 chars) SIZE(3 digits)
+        # VALUE(SIZE chars) fields. Return True when data_str contains a
+        # complete sequence of fields.
+        i = 0
+        while i < len(data_str):
+            size_str = data_str[i + 2 : i + 5]
+            if len(size_str) < 3 or not size_str.isdigit():
+                return False
+            i += 5 + int(size_str)
+        return i > 0 and i == len(data_str)
+
     def _fr_caisse_ap_ip_parse_answer(self, data_str):
         logger.debug("Received raw data: %s", data_str)
         data_dict = {}
@@ -411,9 +462,19 @@ class PosPaymentMethod(models.Model):
             tag = data_str[i : i + 2]
             i += 2
             size_str = data_str[i : i + 3]
+            if len(size_str) < 3 or not size_str.isdigit():
+                raise ValueError(
+                    f"Wrong size '{size_str}' for tag '{tag}': the answer from "
+                    "the payment terminal is malformed or truncated."
+                )
             size = int(size_str)
             i += 3
             value = data_str[i : i + size]
+            if len(value) != size:
+                raise ValueError(
+                    f"Value of tag '{tag}' is truncated: expected {size} chars, "
+                    f"got {len(value)}."
+                )
             data_dict[tag] = value
             i += size
         logger.debug("Answer dict: %s", data_dict)

--- a/l10n_fr_pos_caisse_ap_ip/tests/__init__.py
+++ b/l10n_fr_pos_caisse_ap_ip/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_caisse_ap_ip

--- a/l10n_fr_pos_caisse_ap_ip/tests/test_caisse_ap_ip.py
+++ b/l10n_fr_pos_caisse_ap_ip/tests/test_caisse_ap_ip.py
@@ -1,0 +1,303 @@
+# Copyright 2026 Akretion France (http://www.akretion.com/)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import socket
+import threading
+import time
+
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+class FakeTerminal(threading.Thread):
+    """A fake Caisse-AP payment terminal listening on localhost.
+
+    It accepts one TCP connection, reads the request, builds the answer
+    with the provided callback and sends it back.
+    """
+
+    def __init__(self, answer_builder, chunks=None, close_after_send=True):
+        super().__init__(daemon=True)
+        self.answer_builder = answer_builder
+        self.chunks = chunks
+        self.close_after_send = close_after_send
+        self.request = None
+        self.srv = socket.socket()
+        self.srv.bind(("127.0.0.1", 0))
+        self.srv.listen(1)
+        self.port = self.srv.getsockname()[1]
+
+    @staticmethod
+    def parse(data_str):
+        data_dict = {}
+        i = 0
+        while i < len(data_str):
+            tag = data_str[i : i + 2]
+            size = int(data_str[i + 2 : i + 5])
+            data_dict[tag] = data_str[i + 5 : i + 5 + size]
+            i += 5 + size
+        return data_dict
+
+    @staticmethod
+    def serialize(msg_dict):
+        return "".join(
+            f"{tag}{len(value):03d}{value}" for tag, value in msg_dict.items()
+        )
+
+    def run(self):
+        conn, _addr = self.srv.accept()
+        conn.settimeout(10)
+        self.request = conn.recv(4096).decode("ascii")
+        answer = self.answer_builder(self.parse(self.request))
+        if isinstance(answer, dict):
+            answer = self.serialize(answer)
+        if self.chunks:
+            for part in self.chunks(answer):
+                conn.sendall(part.encode("ascii"))
+                time.sleep(0.05)
+        else:
+            conn.sendall(answer.encode("ascii"))
+        if self.close_after_send:
+            conn.close()
+        else:
+            time.sleep(2)
+            conn.close()
+        self.srv.close()
+
+
+@tagged("post_install", "-at_install")
+class TestCaisseApIp(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.method = cls.env["pos.payment.method"].create(
+            {
+                "name": "Test Caisse-AP terminal",
+                "use_payment_terminal": "fr-caisse_ap_ip",
+                "fr_caisse_ap_ip_address": "127.0.0.1",
+                "fr_caisse_ap_ip_port": 8888,
+            }
+        )
+        cls.eur = cls.env.ref("base.EUR")
+        cls.xpf = cls.env.ref("base.XPF")
+
+    def _payment_data(self, amount, currency=None, timeout=10000):
+        return {
+            "amount": amount,
+            "currency_id": (currency or self.eur).id,
+            "payment_method_id": self.method.id,
+            "payment_id": "test-uuid",
+            "timeout": timeout,
+        }
+
+    def _send(self, amount, answer_builder, currency=None, chunks=None, **kw):
+        terminal = FakeTerminal(answer_builder, chunks=chunks, **kw)
+        terminal.start()
+        self.method.fr_caisse_ap_ip_port = terminal.port
+        res = self.env["pos.payment.method"].fr_caisse_ap_ip_send_payment(
+            self._payment_data(amount, currency=currency)
+        )
+        terminal.join(timeout=10)
+        return res, terminal
+
+    @staticmethod
+    def _success_answer(req):
+        return {
+            "CZ": req["CZ"],
+            "AE": "10",
+            "CA": req["CA"],
+            "CB": "000" + req["CB"],  # a real terminal zero-pads the amount
+            "CD": req["CD"],
+            "CE": req["CE"],
+            "CC": "001",
+            "CI": "1",
+            "AA": "1234",
+            "AB": "123456",
+            "AC": "20260708",
+        }
+
+    # ------------------------------------------------------------------
+    # Configuration constraint
+    # ------------------------------------------------------------------
+    def test_constraint_missing_ip(self):
+        with self.assertRaises(ValidationError):
+            self.method.fr_caisse_ap_ip_address = False
+
+    def test_constraint_invalid_port(self):
+        with self.assertRaises(ValidationError):
+            self.method.fr_caisse_ap_ip_port = 70000
+
+    # ------------------------------------------------------------------
+    # Message preparation and serialization
+    # ------------------------------------------------------------------
+    def test_prepare_msg(self):
+        msg = self.method._fr_caisse_ap_ip_prepare_msg(
+            {"CJ": "012345678901", "CA": "01", "CE": "978", "CD": "0", "CB": "05"}
+        )
+        self.assertTrue(msg.startswith("CZ0040300"))
+        self.assertIn("CB00205", msg)
+        self.assertIn("CE003978", msg)
+
+    def test_prepare_msg_rejects_bad_input(self):
+        for bad in (False, {"payment_status": "issue"}, {"CA": ""}, {"CA": 5}):
+            with self.assertRaises(ValueError):
+                self.method._fr_caisse_ap_ip_prepare_msg(bad)
+
+    def test_prepare_message_eur(self):
+        data = self._payment_data(12.34)
+        msg_dict = self.method._fr_caisse_ap_ip_prepare_message(data)
+        self.assertEqual(msg_dict["CB"], "1234")
+        self.assertEqual(msg_dict["CD"], "0")
+        self.assertEqual(msg_dict["CE"], "978")
+        self.assertNotIn("CC", msg_dict)
+
+    def test_prepare_message_small_amount_is_padded(self):
+        # The protocol requires a minimum size of 2 chars for the CB tag
+        data = self._payment_data(0.05)
+        msg_dict = self.method._fr_caisse_ap_ip_prepare_message(data)
+        self.assertEqual(msg_dict["CB"], "05")
+
+    def test_prepare_message_reimbursement(self):
+        data = self._payment_data(-10.0)
+        msg_dict = self.method._fr_caisse_ap_ip_prepare_message(data)
+        self.assertEqual(msg_dict["CD"], "1")
+        self.assertEqual(msg_dict["CB"], "1000")
+
+    def test_prepare_message_no_decimal_currency(self):
+        data = self._payment_data(1000, currency=self.xpf)
+        msg_dict = self.method._fr_caisse_ap_ip_prepare_message(data)
+        self.assertEqual(msg_dict["CB"], "1000")
+        self.assertEqual(msg_dict["CE"], "953")
+
+    def test_prepare_message_check_mode(self):
+        self.method.fr_caisse_ap_ip_mode = "check"
+        data = self._payment_data(10.0)
+        msg_dict = self.method._fr_caisse_ap_ip_prepare_message(data)
+        self.assertEqual(msg_dict.get("CC"), "00C")
+
+    def test_null_amount_returns_issue(self):
+        res = self.env["pos.payment.method"].fr_caisse_ap_ip_send_payment(
+            self._payment_data(0.0)
+        )
+        self.assertEqual(res["payment_status"], "issue")
+        self.assertIn("null amount", res["error_message"])
+
+    def test_over_maximum_amount_returns_issue(self):
+        res = self.env["pos.payment.method"].fr_caisse_ap_ip_send_payment(
+            self._payment_data(10**12)
+        )
+        self.assertEqual(res["payment_status"], "issue")
+        self.assertIn("maximum", res["error_message"])
+
+    # ------------------------------------------------------------------
+    # Answer parsing
+    # ------------------------------------------------------------------
+    def test_answer_complete(self):
+        complete = self.method._fr_caisse_ap_ip_answer_complete
+        self.assertTrue(complete("CZ0040300AE00210"))
+        self.assertFalse(complete("CZ0040300AE002"))
+        self.assertFalse(complete("CZ0040300AE0"))
+        self.assertFalse(complete(""))
+
+    def test_parse_answer(self):
+        parsed = self.method._fr_caisse_ap_ip_parse_answer(
+            "CZ0040300AE00210CB00205CD0010CE003978CA00201"
+        )
+        self.assertEqual(
+            parsed,
+            {
+                "CZ": "0300",
+                "AE": "10",
+                "CB": "05",
+                "CD": "0",
+                "CE": "978",
+                "CA": "01",
+            },
+        )
+
+    def test_parse_answer_malformed(self):
+        for bad in ("CZ00X0300", "AE00", "AE00510"):
+            with self.assertRaises(ValueError):
+                self.method._fr_caisse_ap_ip_parse_answer(bad)
+
+    def test_check_answer(self):
+        msg_dict = {"CA": "01", "CB": "05", "CD": "0", "CE": "978"}
+        answer = {"CA": "01", "CB": "0000005", "CD": "0", "CE": "978", "AE": "10"}
+        self.assertIs(self.method._fr_caisse_ap_ip_check_answer(answer, msg_dict), True)
+        # missing required tag: the error message must name the tag
+        res = self.method._fr_caisse_ap_ip_check_answer(
+            {"CA": "01", "CD": "0", "CE": "978"}, msg_dict
+        )
+        self.assertEqual(res["payment_status"], "issue")
+        self.assertIn("CB", res["error_message"])
+        # amount mismatch must be detected
+        res = self.method._fr_caisse_ap_ip_check_answer(
+            dict(answer, CB="0000006"), msg_dict
+        )
+        self.assertEqual(res["payment_status"], "issue")
+
+    # ------------------------------------------------------------------
+    # Full exchange with a fake terminal
+    # ------------------------------------------------------------------
+    def test_payment_success(self):
+        res, terminal = self._send(10.0, self._success_answer)
+        self.assertEqual(res["payment_status"], "success")
+        self.assertIn("CB contact", res["card_type"])
+        self.assertIn("AA-1234", res["transaction_id"])
+        self.assertIn("CD-0", res["transaction_id"])
+        self.assertEqual(res["ticket"], "Card type: CB contact")
+        # the request sent on the wire was correct
+        req = FakeTerminal.parse(terminal.request)
+        self.assertEqual(req["CB"], "1000")
+        self.assertEqual(req["CZ"], "0300")
+
+    def test_payment_success_split_answer(self):
+        # The answer arrives in several TCP chunks, split in the middle
+        # of a field: the recv loop must reassemble it
+        res, _terminal = self._send(
+            10.0,
+            self._success_answer,
+            chunks=lambda a: [a[:7], a[7:20], a[20:]],
+        )
+        self.assertEqual(res["payment_status"], "success")
+
+    def test_payment_success_connection_kept_open(self):
+        # The terminal does not close the connection after answering:
+        # the drain logic must still terminate the read
+        res, _terminal = self._send(10.0, self._success_answer, close_after_send=False)
+        self.assertEqual(res["payment_status"], "success")
+
+    def test_payment_failure(self):
+        def failure_answer(req):
+            return {"CZ": req["CZ"], "AE": "01", "AF": "06"}
+
+        res, _terminal = self._send(10.0, failure_answer)
+        self.assertEqual(res["payment_status"], "failure")
+        self.assertIn("Abandon", res["error_message"])
+
+    def test_payment_garbage_answer(self):
+        res, _terminal = self._send(10.0, lambda req: "GARBAGE?!")
+        self.assertEqual(res["payment_status"], "issue")
+
+    def test_payment_wrong_echo(self):
+        def wrong_echo(req):
+            answer = self._success_answer(req)
+            answer["CE"] = "840"  # currency not matching the request
+            return answer
+
+        res, _terminal = self._send(10.0, wrong_echo)
+        self.assertEqual(res["payment_status"], "issue")
+
+    def test_payment_connection_refused(self):
+        # Reserve a port and close it so that nothing listens on it
+        srv = socket.socket()
+        srv.bind(("127.0.0.1", 0))
+        port = srv.getsockname()[1]
+        srv.close()
+        self.method.fr_caisse_ap_ip_port = port
+        res = self.env["pos.payment.method"].fr_caisse_ap_ip_send_payment(
+            self._payment_data(10.0)
+        )
+        self.assertEqual(res["payment_status"], "issue")
+        self.assertIn("127.0.0.1", res["error_message"])

--- a/l10n_fr_pos_caisse_ap_ip/tests/test_caisse_ap_ip.py
+++ b/l10n_fr_pos_caisse_ap_ip/tests/test_caisse_ap_ip.py
@@ -8,6 +8,9 @@ import time
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
+
+MODEL_LOGGER = "odoo.addons.l10n_fr_pos_caisse_ap_ip.models.pos_payment_method"
 
 
 class FakeTerminal(threading.Thread):
@@ -176,6 +179,7 @@ class TestCaisseApIp(TransactionCase):
         msg_dict = self.method._fr_caisse_ap_ip_prepare_message(data)
         self.assertEqual(msg_dict.get("CC"), "00C")
 
+    @mute_logger(MODEL_LOGGER)
     def test_null_amount_returns_issue(self):
         res = self.env["pos.payment.method"].fr_caisse_ap_ip_send_payment(
             self._payment_data(0.0)
@@ -183,6 +187,7 @@ class TestCaisseApIp(TransactionCase):
         self.assertEqual(res["payment_status"], "issue")
         self.assertIn("null amount", res["error_message"])
 
+    @mute_logger(MODEL_LOGGER)
     def test_over_maximum_amount_returns_issue(self):
         res = self.env["pos.payment.method"].fr_caisse_ap_ip_send_payment(
             self._payment_data(10**12)
@@ -276,6 +281,7 @@ class TestCaisseApIp(TransactionCase):
         self.assertEqual(res["payment_status"], "failure")
         self.assertIn("Abandon", res["error_message"])
 
+    @mute_logger(MODEL_LOGGER)
     def test_payment_garbage_answer(self):
         res, _terminal = self._send(10.0, lambda req: "GARBAGE?!")
         self.assertEqual(res["payment_status"], "issue")
@@ -289,6 +295,7 @@ class TestCaisseApIp(TransactionCase):
         res, _terminal = self._send(10.0, wrong_echo)
         self.assertEqual(res["payment_status"], "issue")
 
+    @mute_logger(MODEL_LOGGER)
     def test_payment_connection_refused(self):
         # Reserve a port and close it so that nothing listens on it
         srv = socket.socket()


### PR DESCRIPTION
Fixes several defects found during a code review of the module, plus translation updates.

### Python fixes (models/pos_payment_method.py)

- fr_caisse_ap_ip_send_payment() did not check the return value of _fr_caisse_ap_ip_prepare_message(), which can be False (unsupported currency) or an error dict (null or over-maximum amount). Both cases crashed with a 500 RPC error — the POS displayed the misleading "No answer from the payment terminal in the given time" instead of the prepared error message.
- The answer of the terminal was read with a single recv(1024): answers larger than the buffer or split across TCP packets were silently truncated. The answer is now read in a loop until the message is complete. As the Caisse-AP protocol has no length header nor end-of-message marker, when the buffer parses as a whole number of fields the socket is drained with a short timeout so that a split falling exactly on a field boundary is not mistaken for the end of the answer. A global deadline and a maximum answer size protect against a broken terminal streaming forever.
- sendall() instead of send() to avoid partial writes.
- A malformed or truncated answer made int() raise an unhandled ValueError surfacing as a 500 RPC error. The parser now raises a clear error and the caller converts it into a translated payment-issue message shown to the cashier.
- The CB tag (amount) was sent unpadded: the zfill(2) result was never written back to msg_dict, so amounts under 10 cents were sent with a single digit while the protocol requires a minimum of 2 chars.
- The "required tag missing" error message interpolated the (absent) tag value instead of the tag name, always displaying "tag None".
- The comparison of the CB tag between request and answer now strips leading zeros on both sides.
- Replaced assert with explicit exceptions in _fr_caisse_ap_ip_prepare_msg() so the checks survive python -O.

### Translation updates (i18n/)

- Added the two new user-facing error messages to the POT file, translated in French and Spanish.
- fr: the "Check" payment mode was mistranslated "Vérifier" instead of "Chèque" (the Spanish file correctly says "Cheque").
- fr + es: translated the connection-failure message (the most common runtime error — terminal off/unreachable) which had an empty msgstr.
- fr: translated the tag-mismatch message variant that had an empty msgstr; es: fixed a half-English entry.

### Testing
The pure protocol logic (serialization, TLV parsing, completeness detection, echo check) was exercised with standalone tests, and the new socket read loop was tested against a fake terminal covering: one-shot answer with connection kept open, answer split exactly on a field boundary, answer split mid-field, terminal closing after send, endless garbage stream, silent terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
