### PR TITLE
[18.0][BACKPORT] l10n_fr_siret: check VAT/SIREN consistency

### DIFF
--- a/l10n_fr_das2/demo/demo.xml
+++ b/l10n_fr_das2/demo/demo.xml
@@ -15,8 +15,8 @@
     has child contacts, it will sync the siren with the childs
     while keeping the nic, so the SIRET will become invalid on the childs -->
     <record id="base.main_partner" model="res.partner">
-        <field name="siren">999999998</field>
-        <field name="nic">00019</field>
+        <field name="siren">441019213</field>
+        <field name="nic">00012</field>
     </record>
 
     <!-- DEMO SUPPLIERS -->

--- a/l10n_fr_intrastat_product/demo/intrastat_demo.xml
+++ b/l10n_fr_intrastat_product/demo/intrastat_demo.xml
@@ -15,7 +15,7 @@
     has child contacts, it will sync the siren with the childs
     while keeping the nic, so the SIRET will become invalid on the childs -->
     <record id="base.main_partner" model="res.partner">
-        <field name="siret">99999999800019</field>
+        <field name="siret">44101921300012</field>
     </record>
     <record id="intrastat_product.intrastat_unit_pce" model="intrastat.unit">
         <field name="fr_xml_label">PCE</field>

--- a/l10n_fr_siret/models/res_partner.py
+++ b/l10n_fr_siret/models/res_partner.py
@@ -1,6 +1,6 @@
 import logging
 
-from odoo import _, api, fields, models
+from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError, ValidationError
 
 logger = logging.getLogger(__name__)
@@ -196,6 +196,14 @@ class Partner(models.Model):
     def _get_siren(self, raise_if_none=False):
         self.ensure_one()
         partner = self.parent_id or self
+        running_env = tools.config.get("running_env")
+        # Hack for SUPER PDP sandbox because, unfortunately,
+        # SUPER PDP demo SIRENs don't have a compliant checksum
+        if running_env in ("test", "dev") and partner.siren in (
+            "000000001",
+            "000000002",
+        ):
+            return partner.siren
         if partner.vat:
             vat = "".join(x for x in partner.vat if not x.isspace())
             if (

--- a/l10n_fr_siret/models/res_partner.py
+++ b/l10n_fr_siret/models/res_partner.py
@@ -119,7 +119,7 @@ class Partner(models.Model):
                 is_france_country = True
             partner.is_france_country = is_france_country
 
-    @api.constrains("siren", "nic")
+    @api.constrains("siren", "nic", "vat")
     def _check_siret(self):
         """Check the SIREN's and NIC's keys (last digits)"""
         for rec in self:
@@ -160,6 +160,23 @@ class Partner(models.Model):
                             siret=(rec.siren + rec.nic), partner_name=rec.display_name
                         )
                     )
+                if rec.vat:
+                    vat = "".join(x for x in rec.vat if not x.isspace())
+                    # vat numbers have no spaces when base_vat is installed
+                    # but installation of base_vat doesn't remove spaces in vat numbers
+                    # encoded before the installation of the module
+                    if vat and vat.startswith("FR") and not vat.endswith(rec.siren):
+                        raise ValidationError(
+                            _(
+                                "On partner '%(partner_name)s', "
+                                "the VAT number %(vat)s is not consistent with "
+                                "SIREN %(siren)s: a french VAT number has the 9 "
+                                "digits of SIREN at the end.",
+                                partner_name=rec.display_name,
+                                siren=rec.siren,
+                                vat=vat,
+                            )
+                        )
 
     @api.model
     def _commercial_fields(self):

--- a/l10n_fr_siret/post_install.py
+++ b/l10n_fr_siret/post_install.py
@@ -13,6 +13,13 @@ logger = logging.getLogger(__name__)
 
 def set_siren_nic(env):
     logger.info("Starting data migration of fields siret/siren/nic on res.partner")
+    # Fix demo data a the beginning, to avoid the logger.warning that break tests
+    demo_fr_company = env.ref("base.partner_demo_company_fr", raise_if_not_found=False)
+    if demo_fr_company:
+        demo_fr_company.write({"siret": "74694878500017"})
+        logger.info(
+            "Changed SIRET on demo partner FR Company to be consistent with VAT"
+        )
     partners = (
         env["res.partner"]
         .with_context(active_test=False)

--- a/l10n_fr_siret/post_install.py
+++ b/l10n_fr_siret/post_install.py
@@ -19,8 +19,22 @@ def set_siren_nic(env):
         .search([("siret", "!=", False), ("parent_id", "=", False)])
     )
     for partner in partners:
-        ini_siret = partner.siret.replace(" ", "")
-        if len(ini_siret) == 14 and siret_is_valid(ini_siret):
+        ini_siret = "".join(x for x in partner.siret if not x.isspace())
+        ini_vat = (
+            partner.vat and "".join(x for x in partner.vat if not x.isspace()) or False
+        )
+        if ini_vat and ini_vat.startswith("FR") and not ini_vat.endswith(ini_siret[:9]):
+            siren = ini_vat[-9:]
+            logger.warning(
+                "Removed SIRET %s on partner %s because it is inconsistent with "
+                "VAT %s. Keep only SIREN %s",
+                ini_siret,
+                partner.display_name,
+                ini_vat,
+                siren,
+            )
+            partner.write({"siren": siren, "nic": False})
+        elif len(ini_siret) == 14 and siret_is_valid(ini_siret):
             logger.debug("Setting SIREN and NIC on partner %s", partner.display_name)
             partner.write({"siret": ini_siret})
         elif len(ini_siret) == 9 and siren_is_valid(ini_siret):

--- a/l10n_fr_siret/tests/test_fr_siret.py
+++ b/l10n_fr_siret/tests/test_fr_siret.py
@@ -142,3 +142,31 @@ class TestL10nFrSiret(TransactionCase):
 
         self.assertEqual(partner2.siren, contact.siren)
         self.assertEqual(partner2.nic, contact.nic)
+
+    def test_vat_siren_consistency(self):
+        with self.assertRaises(ValidationError):
+            self.env["res.partner"].create(
+                {
+                    "name": "Test partner1",
+                    "country_id": self.env.ref("base.fr").id,
+                    "siren": "790067136",
+                    "vat": "FR86792377731",
+                }
+            )
+        with self.assertRaises(ValidationError):
+            self.env["res.partner"].create(
+                {
+                    "name": "Test partner1",
+                    "country_id": self.env.ref("base.fr").id,
+                    "siret": "79006713600016",
+                    "vat": "FR86792377731",
+                }
+            )
+        self.env["res.partner"].create(
+            {
+                "name": "Akretion France",
+                "country_id": self.env.ref("base.fr").id,
+                "siren": "792377731",
+                "vat": "FR86792377731",
+            }
+        )


### PR DESCRIPTION
check VAT/SIREN consistency (backport from v19)
Add a small hack to simplify the use of SUPER PDP sanbox for everybody 