### PR TITLE
[16.0][FIX] l10n_fr_siret: fix res_partner.py, self.env._ is just _ in 16.0

### DIFF
--- a/l10n_fr_siret/models/res_partner.py
+++ b/l10n_fr_siret/models/res_partner.py
@@ -218,7 +218,7 @@ class Partner(models.Model):
             return partner.siren
         if raise_if_none:
             raise UserError(
-                self.env._(
+                _(
                     "SIREN is not set on partner '%(partner)s'.",
                     partner=partner.display_name,
                 )
@@ -231,7 +231,7 @@ class Partner(models.Model):
             return self.siret
         if raise_if_none:
             raise UserError(
-                self.env._(
+                _(
                     "SIRET is not set on partner '%(partner)s'.",
                     partner=self.display_name,
                 )
@@ -244,7 +244,7 @@ class Partner(models.Model):
             return self.nic
         if raise_if_none:
             raise UserError(
-                self.env._(
+                _(
                     "NIC is not set on partner '%(partner)s'.",
                     partner=self.display_name,
                 )


### PR DESCRIPTION
Follow-up of https://github.com/OCA/l10n-france/pull/791 : some `self.env._()` calls were not replaced to `_()` when backporting the code from v18 to v16, causing some `AttributeError: 'Environment' object has no attribute '_'`