### PR TITLE
[16.0][FIX] l10n_fr_department_product_origin: fix department domain

### DIFF
--- a/l10n_fr_department_product_origin/models/product_product.py
+++ b/l10n_fr_department_product_origin/models/product_product.py
@@ -51,8 +51,6 @@ class ProductProduct(models.Model):
         for product in self.filtered(lambda x: x.state_id):
             product.department_id_domain = [("state_id", "=", product.state_id.id)]
         for product in self.filtered(lambda x: not x.state_id and x.country_id):
-            product.department_id_domain = [
-                ("state_id", "in", product.country_id.state_ids)
-            ]
+            product.department_id_domain = [("country_id", "=", product.country_id.id)]
         for product in self.filtered(lambda x: not x.state_id and not x.country_id):
             product.department_id_domain = []

--- a/l10n_fr_department_product_origin/models/product_template.py
+++ b/l10n_fr_department_product_origin/models/product_template.py
@@ -54,7 +54,7 @@ class ProductTemplate(models.Model):
             template.department_id_domain = [("state_id", "=", template.state_id.id)]
         for template in self.filtered(lambda x: not x.state_id and x.country_id):
             template.department_id_domain = [
-                ("state_id", "in", template.country_id.state_ids.ids)
+                ("country_id", "=", template.country_id.id)
             ]
         for template in self.filtered(lambda x: not x.state_id and not x.country_id):
             template.department_id_domain = []


### PR DESCRIPTION
fix department domain when only a country is selected. the code was using the `country_id.state_ids` recordset directly in the domain, which is invalid. using `country_id.state_ids.ids` would work, but searching directly on the country is more efficient (it is a related stored field).