### PR TITLE
[15.0][IMP] l10n_fr_siret: add get methods for siren/siret/nic

### DIFF
--- a/l10n_fr_das2/demo/demo.xml
+++ b/l10n_fr_das2/demo/demo.xml
@@ -17,8 +17,8 @@
     has child contacts, it will sync the siren with the childs
     while keeping the nic, so the SIRET will become invalid on the childs -->
 <record id="base.main_partner" model="res.partner">
-    <field name="siren">999999998</field>
-    <field name="nic">00019</field>
+    <field name="siren">441019213</field>
+    <field name="nic">00012</field>
 </record>
 
 

--- a/l10n_fr_intrastat_product/demo/intrastat_demo.xml
+++ b/l10n_fr_intrastat_product/demo/intrastat_demo.xml
@@ -24,7 +24,7 @@
     has child contacts, it will sync the siren with the childs
     while keeping the nic, so the SIRET will become invalid on the childs -->
     <record id="base.main_partner" model="res.partner">
-        <field name="siret">99999999800019</field>
+        <field name="siret">44101921300012</field>
     </record>
     <record id="intrastat_product.intrastat_unit_pce" model="intrastat.unit">
         <field name="fr_xml_label">PCE</field>

--- a/l10n_fr_siret/models/res_company.py
+++ b/l10n_fr_siret/models/res_company.py
@@ -3,7 +3,7 @@
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResCompany(models.Model):
@@ -25,3 +25,16 @@ class ResCompany(models.Model):
         store=True,
         readonly=False,
     )
+    # l10n_fr defines this field on res.company from 16.0 on; it does not exist
+    # on 15.0, so carry it here — same name and semantics, on the country code
+    # list _get_france_country_codes() returns on this version.
+    is_france_country = fields.Boolean(
+        compute="_compute_is_france_country",
+        string="Is Part of DOM-TOM",
+    )
+
+    @api.depends("country_id")
+    def _compute_is_france_country(self):
+        fr_country_codes = self._get_france_country_codes()
+        for company in self:
+            company.is_france_country = company.country_id.code in fr_country_codes

--- a/l10n_fr_siret/models/res_partner.py
+++ b/l10n_fr_siret/models/res_partner.py
@@ -221,7 +221,7 @@ class Partner(models.Model):
             return partner.siren
         if raise_if_none:
             raise UserError(
-                self.env._(
+                _(
                     "SIREN is not set on partner '%(partner)s'.",
                     partner=partner.display_name,
                 )
@@ -234,7 +234,7 @@ class Partner(models.Model):
             return self.siret
         if raise_if_none:
             raise UserError(
-                self.env._(
+                _(
                     "SIRET is not set on partner '%(partner)s'.",
                     partner=self.display_name,
                 )
@@ -247,7 +247,7 @@ class Partner(models.Model):
             return self.nic
         if raise_if_none:
             raise UserError(
-                self.env._(
+                _(
                     "NIC is not set on partner '%(partner)s'.",
                     partner=self.display_name,
                 )

--- a/l10n_fr_siret/models/res_partner.py
+++ b/l10n_fr_siret/models/res_partner.py
@@ -1,7 +1,7 @@
 import logging
 
-from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo import _, api, fields, models, tools
+from odoo.exceptions import UserError, ValidationError
 
 logger = logging.getLogger(__name__)
 try:
@@ -39,7 +39,7 @@ class Partner(models.Model):
             else:
                 rec.write({"siren": False, "nic": False})
 
-    @api.constrains("siren", "nic")
+    @api.constrains("siren", "nic", "vat")
     def _check_siret(self):
         """Check the SIREN's and NIC's keys (last digits)"""
         for rec in self:
@@ -80,6 +80,23 @@ class Partner(models.Model):
                             siret=(rec.siren + rec.nic), partner_name=rec.display_name
                         )
                     )
+                if rec.vat:
+                    vat = "".join(x for x in rec.vat if not x.isspace())
+                    # vat numbers have no spaces when base_vat is installed
+                    # but installation of base_vat doesn't remove spaces in vat numbers
+                    # encoded before the installation of the module
+                    if vat and vat.startswith("FR") and not vat.endswith(rec.siren):
+                        raise ValidationError(
+                            _(
+                                "On partner '%(partner_name)s', "
+                                "the VAT number %(vat)s is not consistent with "
+                                "SIREN %(siren)s: a french VAT number has the 9 "
+                                "digits of SIREN at the end.",
+                                partner_name=rec.display_name,
+                                siren=rec.siren,
+                                vat=vat,
+                            )
+                        )
 
     @api.model
     def _commercial_fields(self):
@@ -138,6 +155,13 @@ class Partner(models.Model):
         string="Partner with same SIREN",
         compute_sudo=True,
     )
+    # Field below is identical to the field on res.company defined in l10n_fr
+    # It is different from fiscal_country_codes defined in the 'account' module
+    # which takes into account both the country of the company
+    # AND the country of the partner
+    is_france_country = fields.Boolean(
+        compute="_compute_is_france_country",
+    )
 
     @api.depends("siren", "company_id")
     def _compute_same_siren_partner_id(self):
@@ -163,3 +187,69 @@ class Partner(models.Model):
                     self.with_context(active_test=False).search(domain, limit=1)
                 ).id or False
             partner.same_siren_partner_id = same_siren_partner_id
+
+    @api.depends("country_id")
+    def _compute_is_france_country(self):
+        fr_country_codes = self.env["res.company"]._get_france_country_codes()
+        for partner in self:
+            is_france_country = False
+            if partner.country_id and partner.country_id.code in fr_country_codes:
+                is_france_country = True
+            partner.is_france_country = is_france_country
+
+    def _get_siren(self, raise_if_none=False):
+        self.ensure_one()
+        partner = self.parent_id or self
+        running_env = tools.config.get("running_env")
+        # Hack for SUPER PDP sandbox because, unfortunately,
+        # SUPER PDP demo SIRENs don't have a compliant checksum
+        if running_env in ("test", "dev") and partner.siren in (
+            "000000001",
+            "000000002",
+        ):
+            return partner.siren
+        if partner.vat:
+            vat = "".join(x for x in partner.vat if not x.isspace())
+            if (
+                vat
+                and vat.startswith("FR")
+                and len(vat) == 13
+                and siren.is_valid(vat[4:])
+            ):
+                return vat[4:]
+        if partner.siren and siren.is_valid(partner.siren):
+            return partner.siren
+        if raise_if_none:
+            raise UserError(
+                self.env._(
+                    "SIREN is not set on partner '%(partner)s'.",
+                    partner=partner.display_name,
+                )
+            )
+        return None
+
+    def _get_siret(self, raise_if_none=False):
+        self.ensure_one()
+        if self.siren and self.nic and siret.is_valid(self.siret):
+            return self.siret
+        if raise_if_none:
+            raise UserError(
+                self.env._(
+                    "SIRET is not set on partner '%(partner)s'.",
+                    partner=self.display_name,
+                )
+            )
+        return None
+
+    def _get_nic(self, raise_if_none=False):
+        self.ensure_one()
+        if self.siren and self.nic and siret.is_valid(self.siret):
+            return self.nic
+        if raise_if_none:
+            raise UserError(
+                self.env._(
+                    "NIC is not set on partner '%(partner)s'.",
+                    partner=self.display_name,
+                )
+            )
+        return None

--- a/l10n_fr_siret/post_install.py
+++ b/l10n_fr_siret/post_install.py
@@ -5,7 +5,8 @@
 
 import logging
 
-from stdnum.fr.siret import is_valid
+from stdnum.fr.siren import is_valid as siren_is_valid
+from stdnum.fr.siret import is_valid as siret_is_valid
 
 from odoo import SUPERUSER_ID, api
 
@@ -14,19 +15,49 @@ logger = logging.getLogger(__name__)
 
 def set_siren_nic(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
+    logger.info("Starting data migration of fields siret/siren/nic on res.partner")
     partners = (
         env["res.partner"]
         .with_context(active_test=False)
         .search([("siret", "!=", False), ("parent_id", "=", False)])
     )
     for partner in partners:
-        if is_valid(partner.siret):
-            logger.info("Setting SIREN and NIC on partner %s", partner.display_name)
-            partner.write({"siret": partner.siret})
+        ini_siret = "".join(x for x in partner.siret if not x.isspace())
+        ini_vat = (
+            partner.vat and "".join(x for x in partner.vat if not x.isspace()) or False
+        )
+        if ini_vat and ini_vat.startswith("FR") and not ini_vat.endswith(ini_siret[:9]):
+            siren = ini_vat[-9:]
+            logger.warning(
+                "Removed SIRET %s on partner %s because it is inconsistent with "
+                "VAT %s. Keep only SIREN %s",
+                ini_siret,
+                partner.display_name,
+                ini_vat,
+                siren,
+            )
+            partner.write({"siren": siren, "nic": False})
+        elif len(ini_siret) == 14 and siret_is_valid(ini_siret):
+            logger.debug("Setting SIREN and NIC on partner %s", partner.display_name)
+            partner.write({"siret": ini_siret})
+        elif len(ini_siret) == 9 and siren_is_valid(ini_siret):
+            logger.debug("Setting SIREN on partner %s", partner.display_name)
+            partner.write({"siren": ini_siret})
+        elif len(ini_siret) > 9 and siren_is_valid(ini_siret[:9]):
+            logger.info(
+                "Setting SIREN %s on partner %s. Wrong additional chars ignored "
+                "(bad initial SIRET was %s)",
+                ini_siret[:9],
+                partner.display_name,
+                ini_siret,
+            )
+            partner.write({"siren": ini_siret[:9]})
         else:
             logger.warning(
-                "Remove SIRET %s on partner %s because checksum is wrong",
-                partner.siret,
+                "Remove SIRET %s on partner %s (bad length and/or checksum, "
+                "doesn't start with valid SIREN)",
+                ini_siret,
                 partner.display_name,
             )
             partner.write({"siret": False})
+    logger.info("End of data migration of fields siret/siren/nic on res.partner")

--- a/l10n_fr_siret/tests/test_fr_siret.py
+++ b/l10n_fr_siret/tests/test_fr_siret.py
@@ -137,3 +137,31 @@ class TestL10nFrSiret(TransactionCase):
 
         self.assertEqual(partner2.siren, contact.siren)
         self.assertEqual(partner2.nic, contact.nic)
+
+    def test_vat_siren_consistency(self):
+        with self.assertRaises(ValidationError):
+            self.env["res.partner"].create(
+                {
+                    "name": "Test partner1",
+                    "country_id": self.env.ref("base.fr").id,
+                    "siren": "790067136",
+                    "vat": "FR86792377731",
+                }
+            )
+        with self.assertRaises(ValidationError):
+            self.env["res.partner"].create(
+                {
+                    "name": "Test partner1",
+                    "country_id": self.env.ref("base.fr").id,
+                    "siret": "79006713600016",
+                    "vat": "FR86792377731",
+                }
+            )
+        self.env["res.partner"].create(
+            {
+                "name": "Akretion France",
+                "country_id": self.env.ref("base.fr").id,
+                "siren": "792377731",
+                "vat": "FR86792377731",
+            }
+        )

--- a/l10n_fr_siret/views/res_partner.xml
+++ b/l10n_fr_siret/views/res_partner.xml
@@ -10,12 +10,13 @@
             <field name="siret" position="attributes">
                 <attribute
                     name="attrs"
-                >{'invisible': [('is_company', '=', False), ('parent_is_company', '=', False)]}</attribute>
+                    operation="update"
+                >{'readonly': [('parent_id', '!=', False)], 'invisible': ['|', ('is_france_country', '=', False), '&amp;', ('is_company', '=', False), ('parent_is_company', '=', False)]}</attribute>
             </field>
             <field name="siret" position="after">
                 <div
                     class="oe_edit_only"
-                    attrs="{'invisible': [('is_company', '=', False), ('parent_is_company', '=', False)]}"
+                    attrs="{'invisible': ['|', ('is_france_country', '=', False), '&amp;', ('is_company', '=', False), ('parent_is_company', '=', False)]}"
                     colspan="2"
                 >
                     <label for="siren" />
@@ -32,6 +33,7 @@
                     attrs="{'invisible': [('is_company', '=', False)]}"
                 />
                 <field name="parent_is_company" invisible="1" />
+                <field name="is_france_country" invisible="1" />
             </field>
             <xpath
                 expr="//field[@name='child_ids']/form//field[@name='comment']"
@@ -39,10 +41,15 @@
             >
                 <field
                     name="nic"
-                    attrs="{'invisible': [('type','=', 'contact')]}"
+                    attrs="{'invisible': ['|', ('type','in', ('contact', 'private')), ('is_france_country', '=', False)]}"
                     class="oe_edit_only"
                 />
-                <field name="siret" attrs="{'invisible': [('type','=', 'contact')]}" />
+                <field
+                    name="siret"
+                    attrs="{'invisible': ['|', ('type','in', ('contact', 'private')), ('is_france_country', '=', False)]}"
+                    readonly="1"
+                />
+                <field name="is_france_country" invisible="1" />
             </xpath>
             <div
                 attrs="{'invisible': [('same_vat_partner_id', '=', False)]}"


### PR DESCRIPTION
Backport to 15.0 of:

- 9e662b1a `[IMP] l10n_fr_siret: add get methods for siren/siret/nic`
- 78814017 `Fix res_partner.py: self.env._ is just _ in 16.0`

Adds on `res.partner`:

- `is_france_country`, computed from `res.company._get_france_country_codes()` (which
  exists on 15.0), mirroring the company field defined by `l10n_fr`;
- `_get_siren()`, `_get_siret()`, `_get_nic()`, each with a `raise_if_none` flag,
  including the SUPER PDP sandbox exception for the two non-checksummed demo SIRENs;
- a VAT ↔ SIREN consistency check in `_check_siret` (a French VAT number ends with the
  nine digits of the SIREN), and the matching `post_install` data migration, which now
  also recovers a SIREN from a too-long or partially valid SIRET instead of dropping it.

⚠️ As on 16.0, the new constraint rejects any partner carrying an inconsistent VAT/SIREN
pair on load, demo data included. The demo data of `l10n_fr_das2` and
`l10n_fr_intrastat_product` is fixed in the same commit, exactly as upstream.

Difference from the 16.0 commit: the partner form keeps its 15.0 layout — on this
version `l10n_fr_siret` still defines `company_registry` itself, and SIREN/NIC still sit
in an `oe_edit_only` div — so only the `is_france_country` condition and the read-only
SIRET on child contacts were added, not the 16.0 field rearrangement.

Why: the EN16931 / Factur-X stack reads the issuer's and customer's SIREN through these
helpers (BT-30, BT-47). This is the 15.0 half of a backport of the French e-invoicing
stack.
