### PR TITLE
[18.0][IMP] l10n_fr_pos_caisse_ap_ip: do not pin an HTTP worker during a payment

### DIFF
--- a/l10n_fr_pos_caisse_ap_ip/__manifest__.py
+++ b/l10n_fr_pos_caisse_ap_ip/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "POS: Caisse-AP payment protocol for France",
-    "version": "18.0.1.5.0",
+    "version": "18.0.1.6.0",
     "category": "Point of Sale",
     "license": "AGPL-3",
     "summary": "Add support for Caisse-AP payment protocol used in France",
@@ -18,6 +18,7 @@
     "assets": {
         "point_of_sale._assets_pos": [
             "l10n_fr_pos_caisse_ap_ip/static/src/app/payment_caisse_ap_ip.esm.js",
+            "l10n_fr_pos_caisse_ap_ip/static/src/app/pos_store.esm.js",
             "l10n_fr_pos_caisse_ap_ip/static/src/overrides/models/models.esm.js",
         ],
     },

--- a/l10n_fr_pos_caisse_ap_ip/i18n/fr.po
+++ b/l10n_fr_pos_caisse_ap_ip/i18n/fr.po
@@ -116,6 +116,13 @@ msgstr "Chèque"
 #. module: l10n_fr_pos_caisse_ap_ip
 #. odoo-python
 #: code:addons/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py:0
+msgid "Could not prepare the request for the payment terminal."
+msgstr ""
+"Impossible de préparer la demande à destination du terminal de paiement."
+
+#. module: l10n_fr_pos_caisse_ap_ip
+#. odoo-python
+#: code:addons/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py:0
 msgid "Empty answer from payment terminal. This should never happen."
 msgstr ""
 "La réponse du terminal de paiement est vide. Cela ne devrait jamais arriver."

--- a/l10n_fr_pos_caisse_ap_ip/i18n/l10n_fr_pos_caisse_ap_ip.pot
+++ b/l10n_fr_pos_caisse_ap_ip/i18n/l10n_fr_pos_caisse_ap_ip.pot
@@ -103,6 +103,12 @@ msgstr ""
 #. module: l10n_fr_pos_caisse_ap_ip
 #. odoo-python
 #: code:addons/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py:0
+msgid "Could not prepare the request for the payment terminal."
+msgstr ""
+
+#. module: l10n_fr_pos_caisse_ap_ip
+#. odoo-python
+#: code:addons/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py:0
 msgid "Empty answer from payment terminal. This should never happen."
 msgstr ""
 

--- a/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py
+++ b/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py
@@ -426,6 +426,9 @@ class PosPaymentMethod(models.Model):
         overwrite each other; the lock makes them queue instead.
         """
         self.ensure_one()
+        # Raw SQL reads the database, not the ORM cache: a pending write of
+        # this very field would otherwise be invisible and get overwritten
+        self.env.flush_all()
         self.env.cr.execute(
             "SELECT fr_caisse_ap_ip_latest_response FROM pos_payment_method "
             "WHERE id = %s FOR UPDATE",

--- a/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py
+++ b/l10n_fr_pos_caisse_ap_ip/models/pos_payment_method.py
@@ -2,11 +2,17 @@
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import json
 import logging
 import socket
+import threading
+import time
 
-from odoo import _, api, fields, models
+import psycopg2
+
+from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.modules.registry import Registry
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +22,149 @@ except ImportError:
     logger.debug("Cannot import pycountry")
 
 BUFFER_SIZE = 1024
+# Connecting to the terminal must fail fast: an unplugged or powered-off
+# terminal should not make the cashier wait for the full payment timeout.
+CONNECT_TIMEOUT = 10
+# Quiet period on a record boundary before considering the answer over
+INTER_FRAGMENT_TIMEOUT = 1
+# Answers kept in the buffer, waiting to be collected by the POS
+MAX_BUFFERED_ANSWERS = 5
+# Concurrent writes on the payment method row are retried, not lost
+WRITE_ATTEMPTS = 5
+RETRY_DELAY = 0.2
+
+# Live sockets, keyed by payment_id, so that a cancellation from the POS can
+# close the connection instead of letting the thread wait for its timeout.
+_ACTIVE_SOCKETS = {}
+_ACTIVE_SOCKETS_LOCK = threading.Lock()
+
+
+def _is_answer_complete(answer):
+    """Caisse-AP answers are a stream of TAG(2) + LENGTH(3) + VALUE records.
+
+    The answer walks complete when the records land exactly on the end of the
+    buffer -- which a mere prefix of records also does, hence the quiet period
+    in _read_answer.
+    """
+    idx = 0
+    while idx < len(answer):
+        if len(answer) < idx + 5:
+            return False
+        try:
+            size = int(answer[idx + 2 : idx + 5])
+        except ValueError:
+            # Not parsable: stop reading and let the parser report the problem
+            return True
+        idx += 5 + size
+    return idx == len(answer)
+
+
+def _read_answer(sock, read_timeout):
+    """Read the whole answer, however the terminal splits it over TCP.
+
+    The protocol carries no total length, so a prefix of complete records is
+    indistinguishable from a complete answer -- reading until the records parse
+    is not enough. Two rules settle it:
+      - mid-record, keep waiting with the full payment timeout;
+      - on a record boundary, wait a short quiet period for a next fragment,
+        and stop when none comes (or when the terminal closes).
+    """
+    buf = b""
+    sock.settimeout(read_timeout)
+    while True:
+        try:
+            chunk = sock.recv(BUFFER_SIZE)
+        except socket.timeout:
+            if not buf:
+                # The terminal never answered at all
+                raise
+            break
+        if not chunk:
+            # Terminal closed the connection: nothing more is coming
+            break
+        buf += chunk
+        sock.settimeout(
+            INTER_FRAGMENT_TIMEOUT
+            if _is_answer_complete(buf.decode("ascii", "replace"))
+            else read_timeout
+        )
+    return buf.decode("ascii")
+
+
+def _talk_to_terminal(msg_bytes, ip_addr, port, read_timeout, payment_id):
+    """Full dialog with the terminal. Runs outside any database cursor."""
+    with socket.create_connection((ip_addr, port), timeout=CONNECT_TIMEOUT) as sock:
+        # create_connection's timeout covers the connection only; it is then
+        # inherited by recv(). _read_answer sets the read timeout explicitly,
+        # otherwise the worst case is twice the intended timeout.
+        with _ACTIVE_SOCKETS_LOCK:
+            _ACTIVE_SOCKETS[payment_id] = sock
+        try:
+            sock.sendall(msg_bytes)
+            return _read_answer(sock, read_timeout)
+        finally:
+            with _ACTIVE_SOCKETS_LOCK:
+                _ACTIVE_SOCKETS.pop(payment_id, None)
+
+
+def _terminal_thread(
+    dbname,
+    method_id,
+    config_id,
+    payment_id,
+    msg_bytes,
+    msg_dict,
+    ip_addr,
+    port,
+    read_timeout,
+):
+    """Dialog with the terminal, off the HTTP worker.
+
+    The worker that received the RPC has already answered the POS: nothing here
+    may hold it. The socket wait happens with no cursor open, and a cursor is
+    taken only to buffer the result and notify the POS over the bus.
+    """
+    threading.current_thread().dbname = dbname
+    answer = False
+    error = False
+    try:
+        answer = _talk_to_terminal(msg_bytes, ip_addr, port, read_timeout, payment_id)
+    except Exception as e:
+        logger.warning("Exception raised in socket to payment terminal: %s", e)
+        error = e
+    for attempt in range(WRITE_ATTEMPTS):
+        try:
+            with Registry(dbname).cursor() as cr:
+                env = api.Environment(cr, SUPERUSER_ID, {})
+                method = env["pos.payment.method"].browse(method_id)
+                res = method._fr_caisse_ap_ip_build_result(
+                    answer, msg_dict, error, ip_addr, port
+                )
+                res["payment_id"] = payment_id
+                # Buffered first: the POS must be able to collect the answer
+                # even if the bus notification never reaches it
+                method._fr_caisse_ap_ip_store_answer(payment_id, res)
+                env["pos.config"].browse(config_id)._notify(
+                    "FR_CAISSE_AP_IP_RESPONSE", res
+                )
+            return
+        except psycopg2.OperationalError as e:
+            # Two terminals answering at the same instant write the same row:
+            # PostgreSQL aborts one of them, and the answer must not be lost
+            logger.info("Concurrent update while recording the answer: %s", e)
+            time.sleep(RETRY_DELAY * (attempt + 1))
+        except Exception:
+            # Never let this thread die silently: the POS would wait forever
+            logger.exception(
+                "Could not record the answer of payment terminal %s:%s", ip_addr, port
+            )
+            return
+    logger.error(
+        "Gave up recording the answer of payment terminal %s:%s after %s attempts",
+        ip_addr,
+        port,
+        WRITE_ATTEMPTS,
+    )
 
 
 class PosPaymentMethod(models.Model):
@@ -50,6 +199,15 @@ class PosPaymentMethod(models.Model):
         "payment terminal. When the option is enabled, Odoo automatically "
         "sends the total residual amount to the payment terminal.",
     )
+
+    # Buffers the answer of the terminal until the POS collects it
+    fr_caisse_ap_ip_latest_response = fields.Char(
+        copy=False, groups="base.group_erp_manager"
+    )
+
+    def _is_write_forbidden(self, fields):
+        # The buffer is written while a session is open, by design
+        return super()._is_write_forbidden(fields - {"fr_caisse_ap_ip_latest_response"})
 
     @api.model
     def _load_pos_data_fields(self, config_id):
@@ -202,12 +360,29 @@ class PosPaymentMethod(models.Model):
 
     @api.model
     def fr_caisse_ap_ip_send_payment(self, data):
-        """Method called by the JS code of this module"""
+        """Method called by the JS code of this module.
+
+        It only prepares the request and hands the dialog over to a thread:
+        talking to the terminal here would pin an HTTP worker (and a database
+        connection) for as long as the customer takes to insert a card and type
+        a PIN, freezing the whole Odoo instance once every worker is busy.
+        """
         logger.debug("fr_caisse_ap_ip_send_payment data=%s", data)
         payment_method_id = data["payment_method_id"]
         payment_method = self.browse(payment_method_id)
         msg_dict = payment_method._fr_caisse_ap_ip_prepare_message(data)
-        msg_str = self._fr_caisse_ap_ip_prepare_msg(msg_dict)
+        if not isinstance(msg_dict, dict):
+            return {
+                "payment_status": "issue",
+                "error_message": _(
+                    "Could not prepare the request for the payment terminal."
+                ),
+            }
+        if "payment_status" in msg_dict:
+            # Synchronous rejection (null amount, amount too large, ...)
+            return msg_dict
+        payment_id = data["payment_id"]
+        msg_str = self._fr_caisse_ap_ip_prepare_msg(dict(msg_dict))
         msg_bytes = msg_str.encode("ascii")
         timeout_ms = data["timeout"]
         # For the timeout of the TCP socket to the payment terminal, we remove
@@ -227,38 +402,105 @@ class PosPaymentMethod(models.Model):
             port,
         )
         logger.debug("Data about to be sent to payment terminal: %s", msg_str)
-        answer = False
-        try:
-            with socket.create_connection((ip_addr, port), timeout=timeout_sec) as sock:
-                sock.send(msg_bytes)
-                answer_bytes = sock.recv(BUFFER_SIZE)
-                answer = answer_bytes.decode("ascii")
-                logger.debug("Answer received from payment terminal: %s", answer)
-        except Exception as e:
-            logger.warning("Exception raised in socket to payment terminal: %s", e)
-            error_msg = _(
-                "Failure in the connection to the payment terminal"
-                " on %(ip_addr)s port %(port)s: %(error)s.",
-                ip_addr=ip_addr,
-                port=port,
-                error=e,
-            )
-            res = {
+        threading.Thread(
+            target=_terminal_thread,
+            args=(
+                self.env.cr.dbname,
+                payment_method_id,
+                data["pos_config_id"],
+                payment_id,
+                msg_bytes,
+                msg_dict,
+                ip_addr,
+                port,
+                timeout_sec,
+            ),
+            daemon=True,
+        ).start()
+        return {"payment_status": "waiting", "payment_id": payment_id}
+
+    def _fr_caisse_ap_ip_lock_buffer(self):
+        """Read the buffer with the row locked, for a safe read-modify-write.
+
+        Reading through the ORM would serve a cached value and let two writers
+        overwrite each other; the lock makes them queue instead.
+        """
+        self.ensure_one()
+        self.env.cr.execute(
+            "SELECT fr_caisse_ap_ip_latest_response FROM pos_payment_method "
+            "WHERE id = %s FOR UPDATE",
+            (self.id,),
+        )
+        row = self.env.cr.fetchone()
+        self.invalidate_recordset(["fr_caisse_ap_ip_latest_response"])
+        return json.loads((row and row[0]) or "{}")
+
+    def _fr_caisse_ap_ip_store_answer(self, payment_id, res):
+        """Buffer the answer, keyed by payment, until the POS collects it.
+
+        Keyed rather than a single slot: a terminal shared by two payments in a
+        row (a cancelled one then its retry) must not have one answer silently
+        overwrite the other.
+        """
+        self.ensure_one()
+        buf = self._fr_caisse_ap_ip_lock_buffer()
+        buf[payment_id] = res
+        # Keep the buffer from growing over a whole session
+        for stale in list(buf)[:-MAX_BUFFERED_ANSWERS]:
+            del buf[stale]
+        self.sudo().fr_caisse_ap_ip_latest_response = json.dumps(buf)
+
+    @api.model
+    def fr_caisse_ap_ip_get_payment_status(self, payment_method_id, payment_id):
+        """Collect the answer of the terminal, once the thread has recorded it.
+
+        The bus notification is the normal path; this is the safety net for a
+        POS that missed it (websocket reconnection, tab woken up late). Answers
+        in a few milliseconds, so it never holds a worker.
+        """
+        payment_method = self.browse(payment_method_id).sudo()
+        buf = payment_method._fr_caisse_ap_ip_lock_buffer()
+        if payment_id not in buf:
+            return {"payment_status": "waiting"}
+        res = buf.pop(payment_id)
+        payment_method.fr_caisse_ap_ip_latest_response = json.dumps(buf)
+        logger.debug("JSON sent back to POS: %s", res)
+        return res
+
+    @api.model
+    def fr_caisse_ap_ip_cancel_payment(self, payment_id):
+        """Close the socket of a payment the cashier gave up on."""
+        with _ACTIVE_SOCKETS_LOCK:
+            sock = _ACTIVE_SOCKETS.get(payment_id)
+        if sock:
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError as e:
+                logger.debug("Could not shutdown terminal socket: %s", e)
+        return True
+
+    def _fr_caisse_ap_ip_build_result(self, answer, msg_dict, error, ip_addr, port):
+        """Turn what came back from the terminal into the POS answer."""
+        if error:
+            return {
                 "payment_status": "issue",
-                "error_message": error_msg,
+                "error_message": _(
+                    "Failure in the connection to the payment terminal"
+                    " on %(ip_addr)s port %(port)s: %(error)s.",
+                    ip_addr=ip_addr,
+                    port=port,
+                    error=error,
+                ),
             }
-            return res
-        if answer:
-            res = self._fr_caisse_ap_ip_answer(answer, msg_dict)
-        else:
-            res = {
+        if not answer:
+            return {
                 "payment_status": "issue",
                 "error_message": _(
                     "Empty answer from payment terminal. This should never happen."
                 ),
             }
-        logger.debug("JSON sent back to POS: %s", res)
-        return res
+        logger.debug("Answer received from payment terminal: %s", answer)
+        return self._fr_caisse_ap_ip_answer(answer, msg_dict)
 
     def _fr_caisse_ap_ip_answer(self, answer, msg_dict):
         answer_dict = self._fr_caisse_ap_ip_parse_answer(answer)

--- a/l10n_fr_pos_caisse_ap_ip/static/src/app/payment_caisse_ap_ip.esm.js
+++ b/l10n_fr_pos_caisse_ap_ip/static/src/app/payment_caisse_ap_ip.esm.js
@@ -10,13 +10,29 @@ import {AlertDialog} from "@web/core/confirmation_dialog/confirmation_dialog";
 import {PaymentInterface} from "@point_of_sale/app/payment/payment_interface";
 import {_t} from "@web/core/l10n/translation";
 
+// Safety net when the bus notification never arrives, in ms
+const POLL_INTERVAL = 5000;
+// Timeout used in the POS and in the back-end, in ms
+const PAYMENT_TIMEOUT = 180000;
+
 export class PaymentCaisseAPIP extends PaymentInterface {
     setup() {
         super.setup(...arguments);
+        // Pending payments, keyed by payment line uuid
+        this.pendingPayments = {};
     }
 
-    async send_payment_cancel() {
+    async send_payment_cancel(order, uuid) {
         super.send_payment_cancel(...arguments);
+        if (this.pendingPayments[uuid]) {
+            this.pos.data
+                .silentCall("pos.payment.method", "fr_caisse_ap_ip_cancel_payment", [
+                    uuid,
+                ])
+                .catch(() => {
+                    // Nothing to do: the terminal keeps the last word
+                });
+        }
         this._show_error(
             _t(
                 "Press the red button on the payment terminal to cancel the transaction."
@@ -53,32 +69,102 @@ export class PaymentCaisseAPIP extends PaymentInterface {
         await super.send_payment_request(...arguments);
         const order = this.pos.get_order();
         const pay_line = order.get_selected_paymentline();
-        // Define the timout used in the POS and in the back-end (in ms)
-        const timeout = 180000;
         const data = {
             amount: pay_line.amount,
             currency_id: this.pos.currency.id,
             payment_method_id: this.payment_method_id.id,
+            pos_config_id: this.pos.config.id,
             payment_id: uuid,
-            timeout: timeout,
+            timeout: PAYMENT_TIMEOUT,
         };
         pay_line.set_payment_status("waitingCard");
         return this.pos.data
             .silentCall("pos.payment.method", "fr_caisse_ap_ip_send_payment", [data])
             .then((response) => {
-                if (response instanceof Object && "payment_status" in response) {
-                    // The response is a valid object
+                if (!(response instanceof Object) || !("payment_status" in response)) {
+                    return this._handle_caisse_ap_ip_unexpected_response(pay_line);
+                }
+                if (response.payment_status !== "waiting") {
+                    // Rejected before the terminal was even contacted
                     return this._handle_caisse_ap_ip_response(pay_line, response);
                 }
-                return this._handle_caisse_ap_ip_unexpected_response(pay_line);
+                // The server talks to the terminal in the background: the answer
+                // comes back over the bus, so no HTTP worker is held meanwhile
+                return this._wait_for_answer(pay_line, uuid);
             })
             .catch(() => {
-                // It should be a request timeout
                 const error_msg = _t(
                     "No answer from the payment terminal in the given time."
                 );
                 return this._handle_error(error_msg);
             });
+    }
+
+    _wait_for_answer(pay_line, uuid) {
+        const deadline = Date.now() + PAYMENT_TIMEOUT;
+        return new Promise((resolve) => {
+            const pending = {pay_line: pay_line, resolve: resolve};
+            this.pendingPayments[uuid] = pending;
+            pending.poll = setInterval(() => {
+                // Safety net: a missed bus notification must not leave the
+                // cashier in front of a screen that never moves
+                this.pos.data
+                    .silentCall(
+                        "pos.payment.method",
+                        "fr_caisse_ap_ip_get_payment_status",
+                        [this.payment_method_id.id, uuid]
+                    )
+                    .then((response) => {
+                        if (
+                            response instanceof Object &&
+                            response.payment_status &&
+                            response.payment_status !== "waiting"
+                        ) {
+                            this.handleTerminalResponse(response, uuid);
+                        } else if (Date.now() > deadline) {
+                            this._give_up(uuid);
+                        }
+                    })
+                    .catch(() => {
+                        if (Date.now() > deadline) {
+                            this._give_up(uuid);
+                        }
+                    });
+            }, POLL_INTERVAL);
+        });
+    }
+
+    handleTerminalResponse(response, uuid) {
+        const payment_id = uuid || response.payment_id;
+        const pending = this.pendingPayments[payment_id];
+        if (!pending) {
+            // Answer of a payment this interface is not waiting for
+            return;
+        }
+        this._clear_pending(payment_id);
+        pending.resolve(
+            this._handle_caisse_ap_ip_response(pending.pay_line, response)
+        );
+    }
+
+    _give_up(uuid) {
+        const pending = this.pendingPayments[uuid];
+        if (!pending) {
+            return;
+        }
+        this._clear_pending(uuid);
+        // Let the cashier force or cancel rather than wait forever
+        pending.resolve(
+            this._handle_caisse_ap_ip_unexpected_response(pending.pay_line)
+        );
+    }
+
+    _clear_pending(uuid) {
+        const pending = this.pendingPayments[uuid];
+        if (pending && pending.poll) {
+            clearInterval(pending.poll);
+        }
+        delete this.pendingPayments[uuid];
     }
 
     _handle_error(msg) {

--- a/l10n_fr_pos_caisse_ap_ip/static/src/app/payment_caisse_ap_ip.esm.js
+++ b/l10n_fr_pos_caisse_ap_ip/static/src/app/payment_caisse_ap_ip.esm.js
@@ -24,7 +24,8 @@ export class PaymentCaisseAPIP extends PaymentInterface {
 
     async send_payment_cancel(order, uuid) {
         super.send_payment_cancel(...arguments);
-        if (this.pendingPayments[uuid]) {
+        const pending = this.pendingPayments[uuid];
+        if (pending) {
             this.pos.data
                 .silentCall("pos.payment.method", "fr_caisse_ap_ip_cancel_payment", [
                     uuid,
@@ -32,6 +33,12 @@ export class PaymentCaisseAPIP extends PaymentInterface {
                 .catch(() => {
                     // Nothing to do: the terminal keeps the last word
                 });
+            // Closing the socket makes the pending read return nothing, which
+            // would surface as "Empty answer from payment terminal. This should
+            // never happen." -- an alarming message for something the cashier
+            // just asked for. Stop waiting here so that answer is ignored.
+            this._clear_pending(uuid);
+            pending.resolve(false);
         }
         this._show_error(
             _t(

--- a/l10n_fr_pos_caisse_ap_ip/static/src/app/pos_store.esm.js
+++ b/l10n_fr_pos_caisse_ap_ip/static/src/app/pos_store.esm.js
@@ -1,0 +1,21 @@
+/*
+    Copyright 2026 Moka Tourisme (https://www.mokatourisme.fr/)
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+*/
+
+import {PosStore} from "@point_of_sale/app/store/pos_store";
+import {patch} from "@web/core/utils/patch";
+
+patch(PosStore.prototype, {
+    async setup() {
+        await super.setup(...arguments);
+        // The server answers the payment request immediately and talks to the
+        // terminal in the background: its answer comes back here.
+        this.data.connectWebSocket("FR_CAISSE_AP_IP_RESPONSE", (response) => {
+            const method = this.models["pos.payment.method"].find(
+                (pm) => pm.use_payment_terminal === "fr-caisse_ap_ip"
+            );
+            method?.payment_terminal?.handleTerminalResponse(response);
+        });
+    },
+});

--- a/l10n_fr_pos_caisse_ap_ip/tests/__init__.py
+++ b/l10n_fr_pos_caisse_ap_ip/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_caisse_ap_ip

--- a/l10n_fr_pos_caisse_ap_ip/tests/test_caisse_ap_ip.py
+++ b/l10n_fr_pos_caisse_ap_ip/tests/test_caisse_ap_ip.py
@@ -1,0 +1,266 @@
+# Copyright 2026 Moka Tourisme (https://www.mokatourisme.fr/)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import socket
+import socketserver
+import threading
+import time
+
+from odoo.tests import TransactionCase, tagged
+from odoo.tools import mute_logger
+
+from ..models.pos_payment_method import (
+    _is_answer_complete,
+    _talk_to_terminal,
+)
+
+
+def build_message(pairs):
+    """Encode a Caisse-AP message: TAG(2) + LENGTH(3) + VALUE, per record."""
+    return "".join("%s%s%s" % (t, str(len(v)).zfill(3), v) for t, v in pairs)
+
+
+def parse_message(msg):
+    out, idx = {}, 0
+    while idx < len(msg):
+        tag = msg[idx : idx + 2]
+        size = int(msg[idx + 2 : idx + 5])
+        out[tag] = msg[idx + 5 : idx + 5 + size]
+        idx += 5 + size
+    return out
+
+
+class FakeTerminal:
+    """A Caisse-AP payment terminal, on a real TCP socket.
+
+    mode: "ok" | "refuse" | "split" | "silent"
+    """
+
+    def __init__(self, mode="ok", delay=0, fragments=1):
+        self.mode = mode
+        self.delay = delay
+        self.fragments = fragments
+        handler = self._make_handler()
+
+        class Server(socketserver.ThreadingTCPServer):
+            allow_reuse_address = True
+            daemon_threads = True
+
+        self.server = Server(("127.0.0.1", 0), handler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def _make_handler(self):
+        terminal = self
+
+        class Handler(socketserver.BaseRequestHandler):
+            def handle(self):
+                req = parse_message(self.request.recv(4096).decode("ascii"))
+                if terminal.mode == "silent":
+                    time.sleep(60)
+                    return
+                time.sleep(terminal.delay)
+                answer = build_message(
+                    [
+                        ("CZ", req.get("CZ", "0300")),
+                        ("CA", req.get("CA", "01")),
+                        ("CB", req.get("CB", "0").zfill(12)),
+                        ("CD", req.get("CD", "0")),
+                        ("CE", req.get("CE", "978")),
+                        ("AE", "01" if terminal.mode == "refuse" else "10"),
+                        ("AF", "04" if terminal.mode == "refuse" else "01"),
+                        ("CC", req.get("CC", "001")),
+                        ("CI", "1"),
+                        ("AA", "123456"),
+                        ("AB", "987654321"),
+                        ("AC", "00000001"),
+                        ("AI", "20260814093000"),
+                    ]
+                ).encode("ascii")
+                if terminal.mode == "split":
+                    # A terminal is free to split its answer over several TCP
+                    # segments: the module must reassemble them
+                    cuts = [answer[:9], answer[9:25], answer[25:]]
+                    for part in cuts:
+                        self.request.sendall(part)
+                        time.sleep(0.2)
+                else:
+                    self.request.sendall(answer)
+
+        return Handler
+
+    def stop(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+
+@tagged("post_install", "-at_install")
+class TestCaisseApIp(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        journal = cls.env["account.journal"].search(
+            [("type", "in", ("bank", "cash"))], limit=1
+        )
+        cls.method = cls.env["pos.payment.method"].create(
+            {
+                "name": "Caisse-AP test terminal",
+                "journal_id": journal.id,
+                "use_payment_terminal": "fr-caisse_ap_ip",
+                "fr_caisse_ap_ip_address": "127.0.0.1",
+                "fr_caisse_ap_ip_port": 8888,
+            }
+        )
+        cls.msg_dict = {
+            "CJ": "012345678901",
+            "CA": "01",
+            "CE": "978",
+            "CD": "0",
+            "CB": "1000",
+        }
+
+    def _request_bytes(self):
+        return self.method._fr_caisse_ap_ip_prepare_msg(dict(self.msg_dict)).encode(
+            "ascii"
+        )
+
+    def _dialog(self, terminal, timeout=10):
+        self.method.fr_caisse_ap_ip_port = terminal.port
+        return _talk_to_terminal(
+            self._request_bytes(), "127.0.0.1", terminal.port, timeout, "test-payment"
+        )
+
+    # --- framing ---------------------------------------------------------
+
+    def test_answer_completeness(self):
+        """A record stream is complete only when it lands on its own end."""
+        self.assertTrue(_is_answer_complete("CZ0040300"))
+        self.assertFalse(_is_answer_complete("CZ004030"))  # value truncated
+        self.assertFalse(_is_answer_complete("CZ00"))  # header truncated
+        self.assertTrue(_is_answer_complete(""))
+
+    # --- dialog with the terminal ---------------------------------------
+
+    def test_nominal_payment(self):
+        terminal = FakeTerminal(mode="ok")
+        self.addCleanup(terminal.stop)
+        answer = self._dialog(terminal)
+        res = self.method._fr_caisse_ap_ip_build_result(
+            answer, self.msg_dict, False, "127.0.0.1", terminal.port
+        )
+        self.assertEqual(res["payment_status"], "success")
+        self.assertIn("AA-123456", res["transaction_id"])
+
+    def test_fragmented_answer(self):
+        """Regression: a single recv() truncated the answer of the terminal.
+
+        The payment was accepted by the terminal, yet the cashier got
+        "the action status is invalid (AE=None)".
+        """
+        terminal = FakeTerminal(mode="split")
+        self.addCleanup(terminal.stop)
+        answer = self._dialog(terminal)
+        res = self.method._fr_caisse_ap_ip_build_result(
+            answer, self.msg_dict, False, "127.0.0.1", terminal.port
+        )
+        self.assertEqual(res["payment_status"], "success")
+        # The trailing records must survive too, not just the status
+        self.assertIn("AI-20260814093000", res["transaction_id"])
+
+    def test_refused_payment(self):
+        terminal = FakeTerminal(mode="refuse")
+        self.addCleanup(terminal.stop)
+        answer = self._dialog(terminal)
+        res = self.method._fr_caisse_ap_ip_build_result(
+            answer, self.msg_dict, False, "127.0.0.1", terminal.port
+        )
+        self.assertEqual(res["payment_status"], "failure")
+
+    def test_silent_terminal(self):
+        """A terminal that never answers must time out, not hang forever."""
+        terminal = FakeTerminal(mode="silent")
+        self.addCleanup(terminal.stop)
+        start = time.monotonic()
+        with self.assertRaises(socket.timeout):
+            self._dialog(terminal, timeout=2)
+        self.assertLess(time.monotonic() - start, 10)
+
+    def test_unreachable_terminal(self):
+        # Nothing listens on this port
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            free_port = probe.getsockname()[1]
+        with self.assertRaises(OSError):
+            _talk_to_terminal(self._request_bytes(), "127.0.0.1", free_port, 5, "x")
+
+    # --- what the POS calls ---------------------------------------------
+
+    @mute_logger("odoo.addons.l10n_fr_pos_caisse_ap_ip.models.pos_payment_method")
+    def test_send_payment_returns_immediately(self):
+        """The RPC must not wait for the terminal: that is the whole point."""
+        terminal = FakeTerminal(mode="ok", delay=5)
+        self.addCleanup(terminal.stop)
+        self.method.fr_caisse_ap_ip_port = terminal.port
+        start = time.monotonic()
+        res = self.env["pos.payment.method"].fr_caisse_ap_ip_send_payment(
+            {
+                "amount": 10.0,
+                "currency_id": self.env.company.currency_id.id,
+                "payment_method_id": self.method.id,
+                "pos_config_id": self.env["pos.config"].search([], limit=1).id,
+                "payment_id": "test-immediate",
+                "timeout": 20000,
+            }
+        )
+        self.assertEqual(res["payment_status"], "waiting")
+        self.assertLess(time.monotonic() - start, 1)
+
+    def test_null_amount_is_rejected_synchronously(self):
+        res = self.env["pos.payment.method"].fr_caisse_ap_ip_send_payment(
+            {
+                "amount": 0.0,
+                "currency_id": self.env.company.currency_id.id,
+                "payment_method_id": self.method.id,
+                "pos_config_id": False,
+                "payment_id": "test-null",
+                "timeout": 20000,
+            }
+        )
+        self.assertEqual(res["payment_status"], "issue")
+
+    def test_answer_buffer_roundtrip(self):
+        """Answers are keyed by payment and collected exactly once."""
+        self.method._fr_caisse_ap_ip_store_answer(
+            "pay-1", {"payment_status": "success", "payment_id": "pay-1"}
+        )
+        self.method._fr_caisse_ap_ip_store_answer(
+            "pay-2", {"payment_status": "failure", "payment_id": "pay-2"}
+        )
+        model = self.env["pos.payment.method"]
+        # One payment must never collect the answer of another
+        self.assertEqual(
+            model.fr_caisse_ap_ip_get_payment_status(self.method.id, "pay-2")[
+                "payment_status"
+            ],
+            "failure",
+        )
+        self.assertEqual(
+            model.fr_caisse_ap_ip_get_payment_status(self.method.id, "pay-1")[
+                "payment_status"
+            ],
+            "success",
+        )
+        # Collected once: a second call finds nothing left
+        self.assertEqual(
+            model.fr_caisse_ap_ip_get_payment_status(self.method.id, "pay-1")[
+                "payment_status"
+            ],
+            "waiting",
+        )
+
+    def test_unknown_payment_is_still_waiting(self):
+        res = self.env["pos.payment.method"].fr_caisse_ap_ip_get_payment_status(
+            self.method.id, "never-sent"
+        )
+        self.assertEqual(res["payment_status"], "waiting")


### PR DESCRIPTION
The dialog with the terminal happened inside the RPC call, so an HTTP worker and its database connection stayed blocked for as long as the customer took to insert a card and type a PIN — up to 177 s. Once every worker was busy the whole Odoo instance stopped answering, not just the point of sale. It now runs in a thread and the answer comes back over the bus, with polling as a fallback.
Also fixes the answer being read with a single recv(): a terminal splitting it over several TCP segments produced "the action status is invalid (AE=None)" on a payment it had actually accepted.