### PR TITLE
[18.0][IMP] l10n_fr_account_invoice_import_facturx + l10n_fr_business_document_import

### DIFF
--- a/l10n_fr_account_invoice_import_facturx/wizard/account_invoice_import.py
+++ b/l10n_fr_account_invoice_import_facturx/wizard/account_invoice_import.py
@@ -10,13 +10,13 @@ class AccountInvoiceImport(models.TransientModel):
 
     def prepare_facturx_xpath_dict(self):
         xpathd = super().prepare_facturx_xpath_dict()
-        xpathd["partner"]["siret"] = [
+        xpathd["partner"]["siren"] = [
             "//ram:ApplicableHeaderTradeAgreement"
             "/ram:SellerTradeParty"
             "/ram:SpecifiedLegalOrganization"
             "/ram:ID[@schemeID='0002']"
         ]
-        xpathd["company"]["siret"] = [
+        xpathd["company"]["siren"] = [
             "//ram:ApplicableHeaderTradeAgreement"
             "/ram:BuyerTradeParty"
             "/ram:SpecifiedLegalOrganization"

--- a/l10n_fr_business_document_import/models/business_document_import.py
+++ b/l10n_fr_business_document_import/models/business_document_import.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from stdnum.fr.siren import is_valid as siren_is_valid
+from stdnum.fr.siren import to_tva
 from stdnum.fr.siret import is_valid as siret_is_valid
 
 from odoo import _, api, models
@@ -37,6 +38,18 @@ class BusinessDocumentImport(models.AbstractModel):
                     + [
                         ("parent_id", "=", False),
                         ("siren", "=", siren),
+                    ],
+                    limit=1,
+                    order=order,
+                )
+                if partner:
+                    return partner
+                vat_from_siren = f"FR{to_tva(siren)}"
+                partner = rpo.search(
+                    domain
+                    + [
+                        ("parent_id", "=", False),
+                        ("vat", "=", vat_from_siren),
                     ],
                     limit=1,
                     order=order,

--- a/l10n_fr_business_document_import/tests/test_business_document_import.py
+++ b/l10n_fr_business_document_import/tests/test_business_document_import.py
@@ -35,3 +35,13 @@ class TestL10nFRBusinessDocumentImport(TransactionCase):
         partner_dict = {"siret": "380 129 866 00022"}
         res = bdio._match_partner(partner_dict, [])
         self.assertIn(res, [partner1, partner2])
+        partner3 = self.env["res.partner"].create(
+            {
+                "name": "Renault",
+                "is_company": True,
+                "vat": "FR63441639465",
+                "country_id": self.env.ref("base.fr").id,
+            }
+        )
+        partner_dict = {"siren": "441639465"}
+        self.assertEqual(bdio._match_partner(partner_dict, []), partner3)


### PR DESCRIPTION
Improve matching of partner upon invoice import:
- in l10n_fr_account_invoice_import_facturx: update code to newer Factur-X syntax
- in l10n_fr_business_document_import: find a partner from SIREN if only VAT is set in Odoo